### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,31 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -9,3 +9,10 @@ Open `index.html` in any modern web browser. No build step or server is required
 You start with only the ability to extort with the boss. As you perform actions new options will unlock. Use the buttons to recruit mooks, assign them to patrols, recruit lieutenants and buy businesses. Progress bars show how long each action takes.
 
 This prototype intentionally uses a very minimal user interface to focus purely on testing the core gameplay loop.
+
+## Deployment
+
+Changes merged into `main` are automatically published to **GitHub Pages**
+using the workflow defined in `.github/workflows/pages.yml`. Once the action
+completes, the game will be available at
+`https://<username>.github.io/gangster-game/`.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish to GitHub Pages
- document automatic deployment in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686cc8883bb08326964a3b4adb225ae6