### PR TITLE
Expand gangsters with assignable tasks

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,19 +18,20 @@
 <body>
 <h1>Mafia Manager Prototype</h1>
 <div class="counter">Money: $<span id="money">0</span></div>
-<div class="counter">Mooks: <span id="mooks">0</span></div>
-<div class="counter">Patrolling: <span id="patrol">0</span></div>
+<div class="counter">Mooks (patrolling): <span id="mooks">0</span></div>
 <div class="counter">Territory: <span id="territory">1</span> block(s)</div>
 <div class="counter">Heat: <span id="heat">0</span></div>
 <div class="counter">Businesses: <span id="businesses">0</span></div>
-<div class="counter">Faces: <span id="faces">0</span></div>
+<div class="counter">Faces: <span id="faces">0</span> - Idle: <span id="facesIdle">0</span> - Extort: <span id="facesExtortCount">0</span> - Hire: <span id="facesHireCount">0</span></div>
+<div class="counter">Boss Task: <span id="bossTask">extort</span></div>
 <div class="counter">Fists: <span id="fists">0</span></div>
 <div class="counter">Brains: <span id="brains">0</span></div>
 <div class="counter">Illicit Businesses: <span id="illicit">0</span></div>
 <hr>
 <div class="action">
-    <button id="bossExtort">Extort with Boss</button>
-    <div id="bossExtortProgress" class="progress hidden"><div class="progress-bar"></div></div>
+    <button id="setBossExtort">Boss to Extort</button>
+    <button id="setBossHire">Boss to Hire</button>
+    <button id="setBossFist">Boss to Fist</button>
 </div>
 
 <div class="action">
@@ -38,9 +39,6 @@
     <div id="recruitMookProgress" class="progress hidden"><div class="progress-bar"></div></div>
 </div>
 
-<div class="action">
-    <button id="assignPatrol" class="hidden">Assign Mook to Patrol</button>
-</div>
 
 <div class="action">
     <button id="recruitLieutenant" class="hidden">Recruit Lieutenant ($20)</button>
@@ -54,7 +52,15 @@
 </div>
 
 <div class="action">
-    <button id="faceExtort" class="hidden">Extort with Face</button>
+    <button id="assignFaceExtort" class="hidden">Assign Face to Extort</button>
+    <button id="unassignFaceExtort" class="hidden">Unassign</button>
+</div>
+<div class="action">
+    <button id="assignFaceHire" class="hidden">Assign Face to Hire</button>
+    <button id="unassignFaceHire" class="hidden">Unassign</button>
+</div>
+<div class="action">
+    <button id="extortAction" class="hidden">Extort</button>
     <div id="faceExtortProgress" class="progress hidden"><div class="progress-bar"></div></div>
 </div>
 
@@ -76,15 +82,17 @@
 const state = {
     money: 0,
     mooks: 0,
-    patrol: 0,
     territory: 1,
     heat: 0,
     businesses: 0,
     faces: 0,
+    faceIdle: 0,
+    faceExtort: 0,
+    faceHire: 0,
     fists: 0,
     brains: 0,
+    bossTask: 'extort',
     unlockedMook: false,
-    unlockedPatrol: false,
     unlockedLieutenant: false,
     unlockedFaceExtort: false,
     unlockedBusiness: false,
@@ -95,19 +103,33 @@ const state = {
 function updateUI() {
     document.getElementById('money').textContent = state.money;
     document.getElementById('mooks').textContent = state.mooks;
-    document.getElementById('patrol').textContent = state.patrol;
     document.getElementById('territory').textContent = state.territory;
     document.getElementById('heat').textContent = state.heat;
     document.getElementById('businesses').textContent = state.businesses;
     document.getElementById('faces').textContent = state.faces;
+    document.getElementById('facesIdle').textContent = state.faceIdle;
+    document.getElementById('facesExtortCount').textContent = state.faceExtort;
+    document.getElementById('facesHireCount').textContent = state.faceHire;
     document.getElementById('fists').textContent = state.fists;
     document.getElementById('brains').textContent = state.brains;
+    document.getElementById('bossTask').textContent = state.bossTask;
 
     document.getElementById('illicit').textContent = state.illicit;
     if (state.unlockedMook) document.getElementById('recruitMook').classList.remove('hidden');
-    if (state.unlockedPatrol) document.getElementById('assignPatrol').classList.remove('hidden');
     if (state.unlockedLieutenant) document.getElementById('recruitLieutenant').classList.remove('hidden');
-    if (state.unlockedFaceExtort && state.faces > 0) document.getElementById('faceExtort').classList.remove('hidden');
+    if (state.unlockedFaceExtort && state.faces > 0) {
+        document.getElementById('assignFaceExtort').classList.remove('hidden');
+        document.getElementById('assignFaceHire').classList.remove('hidden');
+        document.getElementById('unassignFaceExtort').classList.remove('hidden');
+        document.getElementById('unassignFaceHire').classList.remove('hidden');
+        document.getElementById('extortAction').classList.remove('hidden');
+    } else {
+        document.getElementById('assignFaceExtort').classList.add('hidden');
+        document.getElementById('assignFaceHire').classList.add('hidden');
+        document.getElementById('unassignFaceExtort').classList.add('hidden');
+        document.getElementById('unassignFaceHire').classList.add('hidden');
+        document.getElementById('extortAction').classList.add('hidden');
+    }
     if (state.unlockedBusiness) document.getElementById('buyBusiness').classList.remove('hidden');
     if (state.unlockedIllicit && state.businesses > state.illicit && state.brains > 0) document.getElementById("buildIllicit").classList.remove("hidden");
     else document.getElementById("buildIllicit").classList.add("hidden");
@@ -151,42 +173,33 @@ function showLieutenantTypeSelection(callback) {
     document.getElementById('chooseBrain').onclick = () => choose('brain');
 }
 
-function bossExtort() {
-    document.getElementById('bossExtort').disabled = true;
-    runProgress('bossExtortProgress', 3000, () => {
-        state.money += 10;
-        state.unlockedMook = true;
-        document.getElementById('bossExtort').disabled = false;
-    });
+function setBossTask(task) {
+    state.bossTask = task;
+    updateUI();
 }
 
-document.getElementById('bossExtort').onclick = bossExtort;
+document.getElementById('setBossExtort').onclick = () => setBossTask('extort');
+document.getElementById('setBossHire').onclick = () => setBossTask('hire');
+document.getElementById('setBossFist').onclick = () => setBossTask('fist');
+
 
 function recruitMook() {
-    if (state.money < 5) return alert('Not enough money');
+    const recruiters = state.faceHire + (state.bossTask === 'hire' ? 1 : 0);
+    if (recruiters <= 0) return alert('No gangsters assigned to hire');
+    const totalCost = 5 * recruiters;
+    if (state.money < totalCost) return alert('Not enough money');
     document.getElementById('recruitMook').disabled = true;
-    state.money -= 5;
+    state.money -= totalCost;
     runProgress('recruitMookProgress', 2000, () => {
-        state.mooks += 1;
-        state.unlockedPatrol = true;
+        state.mooks += recruiters;
         state.unlockedLieutenant = true;
         document.getElementById('recruitMook').disabled = false;
+        checkHeat();
     });
 }
 
 document.getElementById('recruitMook').onclick = recruitMook;
 
-function assignPatrol() {
-    if (state.mooks <= 0) return alert('No available mooks');
-    state.mooks -= 1;
-    state.patrol += 1;
-    if (state.patrol < state.territory) {
-        state.heat += 1; // not enough patrol, heat rises
-    }
-    updateUI();
-}
-
-document.getElementById('assignPatrol').onclick = assignPatrol;
 
 function recruitLieutenant() {
     if (state.money < 20) return alert('Not enough money');
@@ -194,7 +207,11 @@ function recruitLieutenant() {
     state.money -= 20;
     runProgress('recruitLieutenantProgress', 3000, () => {
         showLieutenantTypeSelection(choice => {
-            if (choice === 'face') { state.faces += 1; state.unlockedFaceExtort = true; }
+            if (choice === 'face') { 
+                state.faces += 1; 
+                state.faceIdle += 1; 
+                state.unlockedFaceExtort = true; 
+            }
             else if (choice === 'fist') { state.fists += 1; }
             else if (choice === 'brain') { state.brains += 1; }
             document.getElementById('recruitLieutenant').disabled = false;
@@ -204,19 +221,58 @@ function recruitLieutenant() {
 
 document.getElementById('recruitLieutenant').onclick = recruitLieutenant;
 
-function faceExtort() {
-    if (state.faces <= 0) return alert('Need a face lieutenant');
-    document.getElementById('faceExtort').disabled = true;
+function extortAction() {
+    const extorters = state.faceExtort + (state.bossTask === 'extort' ? 1 : 0);
+    if (extorters <= 0) return alert('No gangsters assigned to extort');
+    document.getElementById('extortAction').disabled = true;
     runProgress('faceExtortProgress', 4000, () => {
-        state.money += 15 * state.territory;
-        state.territory += 1;
-        if (state.patrol < state.territory) state.heat += 1;
-        document.getElementById('faceExtort').disabled = false;
+        state.money += 15 * state.territory * extorters;
+        state.territory += extorters;
+        if (state.mooks < state.territory) state.heat += 1;
+        document.getElementById('extortAction').disabled = false;
         state.unlockedBusiness = true;
+        state.unlockedMook = true;
     });
 }
 
-document.getElementById('faceExtort').onclick = faceExtort;
+document.getElementById('extortAction').onclick = extortAction;
+
+function assignFaceExtort() {
+    if (state.faceIdle <= 0) return alert('No idle faces');
+    state.faceIdle -= 1;
+    state.faceExtort += 1;
+    updateUI();
+}
+
+function unassignFaceExtort() {
+    if (state.faceExtort <= 0) return;
+    state.faceExtort -= 1;
+    state.faceIdle += 1;
+    updateUI();
+}
+
+function assignFaceHire() {
+    if (state.faceIdle <= 0) return alert('No idle faces');
+    state.faceIdle -= 1;
+    state.faceHire += 1;
+    updateUI();
+}
+
+function unassignFaceHire() {
+    if (state.faceHire <= 0) return;
+    state.faceHire -= 1;
+    state.faceIdle += 1;
+    updateUI();
+}
+
+document.getElementById('assignFaceExtort').onclick = assignFaceExtort;
+document.getElementById('unassignFaceExtort').onclick = unassignFaceExtort;
+document.getElementById('assignFaceHire').onclick = assignFaceHire;
+document.getElementById('unassignFaceHire').onclick = unassignFaceHire;
+
+function checkHeat() {
+    if (state.mooks < state.territory) state.heat += 1;
+}
 
 function buyBusiness() {
     if (state.money < 100) return alert('Not enough money');


### PR DESCRIPTION
## Summary
- let mooks automatically patrol and remove patrol assignments
- allow faces to be assigned to extort or hire duties
- make the boss a multi‑purpose gangster with selectable tasks
- update UI with new counters and assignment controls

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686d4a026a948326883a3513635f6b7c