### PR TITLE
Implement lieutenant task system

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@
 <h1>Mafia Manager Prototype</h1>
 <div class="counter">Money: $<span id="money">0</span></div>
 <div class="counter">Mooks: <span id="mooks">0</span></div>
-<div class="counter">Patrolling: <span id="patrol">0</span></div>
 <div class="counter">Territory: <span id="territory">1</span> block(s)</div>
 <div class="counter">Heat: <span id="heat">0</span></div>
 <div class="counter">Businesses: <span id="businesses">0</span></div>
@@ -28,18 +27,10 @@
 <div class="counter">Brains: <span id="brains">0</span></div>
 <div class="counter">Illicit Businesses: <span id="illicit">0</span></div>
 <hr>
-<div class="action">
-    <button id="bossExtort">Extort with Boss</button>
-    <div id="bossExtortProgress" class="progress hidden"><div class="progress-bar"></div></div>
-</div>
-
+<div id="lieutenants"></div>
 <div class="action">
     <button id="recruitMook" class="hidden">Recruit Mook ($5)</button>
     <div id="recruitMookProgress" class="progress hidden"><div class="progress-bar"></div></div>
-</div>
-
-<div class="action">
-    <button id="assignPatrol" class="hidden">Assign Mook to Patrol</button>
 </div>
 
 <div class="action">
@@ -53,18 +44,10 @@
     <button id="chooseBrain">Brain</button>
 </div>
 
-<div class="action">
-    <button id="faceExtort" class="hidden">Extort with Face</button>
-    <div id="faceExtortProgress" class="progress hidden"><div class="progress-bar"></div></div>
-</div>
 
 <div class="action">
     <button id="buyBusiness" class="hidden">Buy Business ($100)</button>
     <div id="buyBusinessProgress" class="progress hidden"><div class="progress-bar"></div></div>
-</div>
-<div class="action">
-    <button id="buildIllicit" class="hidden">Build Illicit Business</button>
-    <div id="buildIllicitProgress" class="progress hidden"><div class="progress-bar"></div></div>
 </div>
 
 <div class="action">
@@ -76,26 +59,20 @@
 const state = {
     money: 0,
     mooks: 0,
-    patrol: 0,
     territory: 1,
     heat: 0,
     businesses: 0,
     faces: 0,
     fists: 0,
     brains: 0,
-    unlockedMook: false,
-    unlockedPatrol: false,
-    unlockedLieutenant: false,
-    unlockedFaceExtort: false,
-    unlockedBusiness: false,
     illicit: 0,
-    unlockedIllicit: false,
+    lieutenants: [{ type: 'boss' }],
+    unlocks: new Set(),
 };
 
 function updateUI() {
     document.getElementById('money').textContent = state.money;
     document.getElementById('mooks').textContent = state.mooks;
-    document.getElementById('patrol').textContent = state.patrol;
     document.getElementById('territory').textContent = state.territory;
     document.getElementById('heat').textContent = state.heat;
     document.getElementById('businesses').textContent = state.businesses;
@@ -104,19 +81,18 @@ function updateUI() {
     document.getElementById('brains').textContent = state.brains;
 
     document.getElementById('illicit').textContent = state.illicit;
-    if (state.unlockedMook) document.getElementById('recruitMook').classList.remove('hidden');
-    if (state.unlockedPatrol) document.getElementById('assignPatrol').classList.remove('hidden');
-    if (state.unlockedLieutenant) document.getElementById('recruitLieutenant').classList.remove('hidden');
-    if (state.unlockedFaceExtort && state.faces > 0) document.getElementById('faceExtort').classList.remove('hidden');
-    if (state.unlockedBusiness) document.getElementById('buyBusiness').classList.remove('hidden');
-    if (state.unlockedIllicit && state.businesses > state.illicit && state.brains > 0) document.getElementById("buildIllicit").classList.remove("hidden");
-    else document.getElementById("buildIllicit").classList.add("hidden");
+    if (state.unlocks.has('recruitMook')) document.getElementById('recruitMook').classList.remove('hidden');
+    if (state.unlocks.has('recruitLieutenant')) document.getElementById('recruitLieutenant').classList.remove('hidden');
+    if (state.unlocks.has('buyBusiness')) document.getElementById('buyBusiness').classList.remove('hidden');
     if (state.heat > 0) document.getElementById('payCops').classList.remove('hidden');
+    renderLieutenants();
 }
 
-function runProgress(progressId, duration, callback) {
-    const bar = document.querySelector(`#${progressId} .progress-bar`);
-    const container = document.getElementById(progressId);
+function runProgress(progressIdOrEl, duration, callback) {
+    const container = typeof progressIdOrEl === 'string'
+        ? document.getElementById(progressIdOrEl)
+        : progressIdOrEl;
+    const bar = container.querySelector('.progress-bar');
     container.classList.remove('hidden');
     bar.style.width = '0%';
     const start = Date.now();
@@ -151,16 +127,52 @@ function showLieutenantTypeSelection(callback) {
     document.getElementById('chooseBrain').onclick = () => choose('brain');
 }
 
-function bossExtort() {
-    document.getElementById('bossExtort').disabled = true;
-    runProgress('bossExtortProgress', 3000, () => {
-        state.money += 10;
-        state.unlockedMook = true;
-        document.getElementById('bossExtort').disabled = false;
+function renderLieutenants() {
+    const container = document.getElementById('lieutenants');
+    container.innerHTML = '';
+    state.lieutenants.forEach((lt, idx) => {
+        const row = document.createElement('div');
+        row.className = 'action';
+        const label = document.createElement('span');
+        label.textContent = lt.type === 'boss'
+            ? 'Boss'
+            : lt.type.charAt(0).toUpperCase() + lt.type.slice(1);
+        row.appendChild(label);
+
+        if (lt.type === 'face' || lt.type === 'boss') {
+            const extortBtn = document.createElement('button');
+            extortBtn.textContent = 'Extort';
+            extortBtn.onclick = () => lieutenantExtort(idx);
+            row.appendChild(extortBtn);
+
+            const hireBtn = document.createElement('button');
+            hireBtn.textContent = 'Hire Mook';
+            hireBtn.onclick = () => lieutenantHire(idx);
+            row.appendChild(hireBtn);
+        }
+
+        if (lt.type === 'brain' || lt.type === 'boss') {
+            const buildBtn = document.createElement('button');
+            buildBtn.textContent = 'Build Illicit';
+            buildBtn.onclick = () => lieutenantBuild(idx);
+            if (!state.unlocks.has('buildIllicit')) buildBtn.classList.add('hidden');
+            row.appendChild(buildBtn);
+        }
+
+        const progress = document.createElement('div');
+        progress.className = 'progress hidden';
+        progress.innerHTML = '<div class="progress-bar"></div>';
+        row.appendChild(progress);
+        lt.progressEl = progress;
+
+        container.appendChild(row);
     });
 }
 
-document.getElementById('bossExtort').onclick = bossExtort;
+function checkHeat() {
+    if (state.mooks < state.territory) state.heat += 1;
+}
+
 
 function recruitMook() {
     if (state.money < 5) return alert('Not enough money');
@@ -168,25 +180,12 @@ function recruitMook() {
     state.money -= 5;
     runProgress('recruitMookProgress', 2000, () => {
         state.mooks += 1;
-        state.unlockedPatrol = true;
-        state.unlockedLieutenant = true;
+        state.unlocks.add('recruitLieutenant');
         document.getElementById('recruitMook').disabled = false;
     });
 }
 
 document.getElementById('recruitMook').onclick = recruitMook;
-
-function assignPatrol() {
-    if (state.mooks <= 0) return alert('No available mooks');
-    state.mooks -= 1;
-    state.patrol += 1;
-    if (state.patrol < state.territory) {
-        state.heat += 1; // not enough patrol, heat rises
-    }
-    updateUI();
-}
-
-document.getElementById('assignPatrol').onclick = assignPatrol;
 
 function recruitLieutenant() {
     if (state.money < 20) return alert('Not enough money');
@@ -194,7 +193,8 @@ function recruitLieutenant() {
     state.money -= 20;
     runProgress('recruitLieutenantProgress', 3000, () => {
         showLieutenantTypeSelection(choice => {
-            if (choice === 'face') { state.faces += 1; state.unlockedFaceExtort = true; }
+            state.lieutenants.push({ type: choice });
+            if (choice === 'face') { state.faces += 1; }
             else if (choice === 'fist') { state.fists += 1; }
             else if (choice === 'brain') { state.brains += 1; }
             document.getElementById('recruitLieutenant').disabled = false;
@@ -204,19 +204,39 @@ function recruitLieutenant() {
 
 document.getElementById('recruitLieutenant').onclick = recruitLieutenant;
 
-function faceExtort() {
-    if (state.faces <= 0) return alert('Need a face lieutenant');
-    document.getElementById('faceExtort').disabled = true;
-    runProgress('faceExtortProgress', 4000, () => {
-        state.money += 15 * state.territory;
-        state.territory += 1;
-        if (state.patrol < state.territory) state.heat += 1;
-        document.getElementById('faceExtort').disabled = false;
-        state.unlockedBusiness = true;
+function lieutenantExtort(index) {
+    const lt = state.lieutenants[index];
+    const duration = lt.type === 'boss' ? 3000 : 4000;
+    runProgress(lt.progressEl, duration, () => {
+        if (lt.type === 'boss') {
+            state.money += 10;
+            state.unlocks.add('recruitMook');
+        } else {
+            state.money += 15 * state.territory;
+            state.territory += 1;
+            state.unlocks.add('buyBusiness');
+        }
+        checkHeat();
     });
 }
 
-document.getElementById('faceExtort').onclick = faceExtort;
+function lieutenantHire(index) {
+    if (state.money < 5) return alert('Not enough money');
+    const lt = state.lieutenants[index];
+    state.money -= 5;
+    runProgress(lt.progressEl, 2000, () => {
+        state.mooks += 1;
+        state.unlocks.add('recruitLieutenant');
+    });
+}
+
+function lieutenantBuild(index) {
+    if (state.businesses <= state.illicit) return alert('No available fronts');
+    const lt = state.lieutenants[index];
+    runProgress(lt.progressEl, 4000, () => {
+        state.illicit += 1;
+    });
+}
 
 function buyBusiness() {
     if (state.money < 100) return alert('Not enough money');
@@ -224,25 +244,13 @@ function buyBusiness() {
     state.money -= 100;
     runProgress('buyBusinessProgress', 5000, () => {
         state.businesses += 1;
-        state.unlockedIllicit = true;
+        state.unlocks.add('buildIllicit');
         document.getElementById('buyBusiness').disabled = false;
     });
 }
 
 document.getElementById('buyBusiness').onclick = buyBusiness;
 
-function buildIllicit() {
-    if (state.businesses <= state.illicit) return alert("No available fronts");
-    if (state.brains <= 0) return alert("Need a brain lieutenant");
-    document.getElementById("buildIllicit").disabled = true;
-    state.brains -= 1;
-    runProgress("buildIllicitProgress", 4000, () => {
-        state.illicit += 1;
-        document.getElementById("buildIllicit").disabled = false;
-    });
-}
-
-document.getElementById("buildIllicit").onclick = buildIllicit;
 
 function payCops() {
     if (state.money < 50) return alert('Not enough money');


### PR DESCRIPTION
## Summary
- refactor game state to use a unified set of lieutenants
- automatically patrol with unassigned mooks
- allow faces and boss to extort or hire mooks, brains to build illicit fronts
- remove patrolling controls and per-lieutenant extort buttons
- centralize unlocks into a set

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686dd944ba108326b2209fa82ff42675