### PR TITLE
Refactor mook patrol and lieut tasks

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,7 @@
 <body>
 <h1>Mafia Manager Prototype</h1>
 <div class="counter">Money: $<span id="money">0</span></div>
-<div class="counter">Mooks: <span id="mooks">0</span></div>
-<div class="counter">Patrolling: <span id="patrol">0</span></div>
+<div class="counter">Mooks (patrolling): <span id="mooks">0</span></div>
 <div class="counter">Territory: <span id="territory">1</span> block(s)</div>
 <div class="counter">Heat: <span id="heat">0</span></div>
 <div class="counter">Businesses: <span id="businesses">0</span></div>
@@ -28,19 +27,13 @@
 <div class="counter">Brains: <span id="brains">0</span></div>
 <div class="counter">Illicit Businesses: <span id="illicit">0</span></div>
 <hr>
-<div class="action">
-    <button id="bossExtort">Extort with Boss</button>
-    <div id="bossExtortProgress" class="progress hidden"><div class="progress-bar"></div></div>
-</div>
+<div id="lieutenantList"></div>
 
 <div class="action">
     <button id="recruitMook" class="hidden">Recruit Mook ($5)</button>
     <div id="recruitMookProgress" class="progress hidden"><div class="progress-bar"></div></div>
 </div>
 
-<div class="action">
-    <button id="assignPatrol" class="hidden">Assign Mook to Patrol</button>
-</div>
 
 <div class="action">
     <button id="recruitLieutenant" class="hidden">Recruit Lieutenant ($20)</button>
@@ -53,18 +46,10 @@
     <button id="chooseBrain">Brain</button>
 </div>
 
-<div class="action">
-    <button id="faceExtort" class="hidden">Extort with Face</button>
-    <div id="faceExtortProgress" class="progress hidden"><div class="progress-bar"></div></div>
-</div>
 
 <div class="action">
     <button id="buyBusiness" class="hidden">Buy Business ($100)</button>
     <div id="buyBusinessProgress" class="progress hidden"><div class="progress-bar"></div></div>
-</div>
-<div class="action">
-    <button id="buildIllicit" class="hidden">Build Illicit Business</button>
-    <div id="buildIllicitProgress" class="progress hidden"><div class="progress-bar"></div></div>
 </div>
 
 <div class="action">
@@ -76,41 +61,40 @@
 const state = {
     money: 0,
     mooks: 0,
-    patrol: 0,
     territory: 1,
     heat: 0,
     businesses: 0,
-    faces: 0,
-    fists: 0,
-    brains: 0,
-    unlockedMook: false,
-    unlockedPatrol: false,
-    unlockedLieutenant: false,
-    unlockedFaceExtort: false,
-    unlockedBusiness: false,
     illicit: 0,
-    unlockedIllicit: false,
+    leutenants: [{ id: 0, type: 'boss', busy: false }],
+    unlocks: {
+        recruitMook: false,
+        recruitLieutenant: false,
+        faceExtort: false,
+        buyBusiness: false,
+        buildIllicit: false,
+    },
 };
 
 function updateUI() {
     document.getElementById('money').textContent = state.money;
     document.getElementById('mooks').textContent = state.mooks;
-    document.getElementById('patrol').textContent = state.patrol;
     document.getElementById('territory').textContent = state.territory;
     document.getElementById('heat').textContent = state.heat;
     document.getElementById('businesses').textContent = state.businesses;
-    document.getElementById('faces').textContent = state.faces;
-    document.getElementById('fists').textContent = state.fists;
-    document.getElementById('brains').textContent = state.brains;
+    const faces = state.leutenants.filter(l => l.type === 'face').length;
+    const fists = state.leutenants.filter(l => l.type === 'fist').length;
+    const brains = state.leutenants.filter(l => l.type === 'brain').length;
+    document.getElementById('faces').textContent = faces;
+    document.getElementById('fists').textContent = fists;
+    document.getElementById('brains').textContent = brains;
 
     document.getElementById('illicit').textContent = state.illicit;
-    if (state.unlockedMook) document.getElementById('recruitMook').classList.remove('hidden');
-    if (state.unlockedPatrol) document.getElementById('assignPatrol').classList.remove('hidden');
-    if (state.unlockedLieutenant) document.getElementById('recruitLieutenant').classList.remove('hidden');
-    if (state.unlockedFaceExtort && state.faces > 0) document.getElementById('faceExtort').classList.remove('hidden');
-    if (state.unlockedBusiness) document.getElementById('buyBusiness').classList.remove('hidden');
-    if (state.unlockedIllicit && state.businesses > state.illicit && state.brains > 0) document.getElementById("buildIllicit").classList.remove("hidden");
-    else document.getElementById("buildIllicit").classList.add("hidden");
+    for (const key in state.unlocks) {
+        const el = document.getElementById(key);
+        if (!el) continue;
+        if (state.unlocks[key]) el.classList.remove('hidden');
+        else el.classList.add('hidden');
+    }
     if (state.heat > 0) document.getElementById('payCops').classList.remove('hidden');
 }
 
@@ -133,6 +117,58 @@ function runProgress(progressId, duration, callback) {
     }, 100);
 }
 
+function renderLeutenants() {
+    const container = document.getElementById('lieutenantList');
+    container.innerHTML = '';
+    state.leutenants.forEach(l => {
+        const row = document.createElement('div');
+        row.className = 'action';
+        const label = document.createElement('span');
+        label.textContent = l.type === 'boss' ? 'Boss' : l.type.charAt(0).toUpperCase() + l.type.slice(1);
+        row.appendChild(label);
+        const tasks = ['extort', 'recruitMook'];
+        if (l.type === 'brain' || l.type === 'boss') tasks.push('buildIllicit');
+        tasks.forEach(t => {
+            const btn = document.createElement('button');
+            btn.textContent = t === 'recruitMook' ? 'Hire Mook' : t === 'buildIllicit' ? 'Build Illicit' : 'Extort';
+            btn.onclick = () => startTask(l, t, row);
+            row.appendChild(btn);
+        });
+        const progress = document.createElement('div');
+        progress.id = `progress-${l.id}`;
+        progress.className = 'progress hidden';
+        progress.innerHTML = '<div class="progress-bar"></div>';
+        row.appendChild(progress);
+        container.appendChild(row);
+    });
+}
+
+function startTask(leut, task, row) {
+    if (leut.busy) return;
+    const buttons = row.querySelectorAll('button');
+    const progressId = `progress-${leut.id}`;
+    const duration = task === 'recruitMook' ? 2000 : 4000;
+    if (task === 'recruitMook' && state.money < 5) return alert('Not enough money');
+    if (task === 'buildIllicit' && state.businesses <= state.illicit) return alert('No available fronts');
+    buttons.forEach(b => b.disabled = true);
+    if (task === 'recruitMook') state.money -= 5;
+    runProgress(progressId, duration, () => {
+        if (task === 'extort') {
+            state.money += 15 * state.territory;
+            state.territory += 1;
+            if (state.mooks < state.territory) state.heat += 1;
+            state.unlocks.recruitMook = true;
+            state.unlocks.buyBusiness = true;
+        } else if (task === 'recruitMook') {
+            state.mooks += 1;
+            state.unlocks.recruitLieutenant = true;
+        } else if (task === 'buildIllicit') {
+            state.illicit += 1;
+        }
+        buttons.forEach(b => b.disabled = false);
+    });
+}
+
 function showLieutenantTypeSelection(callback) {
     const container = document.getElementById('lieutenantChoice');
     container.classList.remove('hidden');
@@ -151,16 +187,6 @@ function showLieutenantTypeSelection(callback) {
     document.getElementById('chooseBrain').onclick = () => choose('brain');
 }
 
-function bossExtort() {
-    document.getElementById('bossExtort').disabled = true;
-    runProgress('bossExtortProgress', 3000, () => {
-        state.money += 10;
-        state.unlockedMook = true;
-        document.getElementById('bossExtort').disabled = false;
-    });
-}
-
-document.getElementById('bossExtort').onclick = bossExtort;
 
 function recruitMook() {
     if (state.money < 5) return alert('Not enough money');
@@ -168,55 +194,32 @@ function recruitMook() {
     state.money -= 5;
     runProgress('recruitMookProgress', 2000, () => {
         state.mooks += 1;
-        state.unlockedPatrol = true;
-        state.unlockedLieutenant = true;
+        state.unlocks.recruitLieutenant = true;
         document.getElementById('recruitMook').disabled = false;
     });
 }
 
 document.getElementById('recruitMook').onclick = recruitMook;
 
-function assignPatrol() {
-    if (state.mooks <= 0) return alert('No available mooks');
-    state.mooks -= 1;
-    state.patrol += 1;
-    if (state.patrol < state.territory) {
-        state.heat += 1; // not enough patrol, heat rises
-    }
-    updateUI();
-}
-
-document.getElementById('assignPatrol').onclick = assignPatrol;
-
 function recruitLieutenant() {
     if (state.money < 20) return alert('Not enough money');
     document.getElementById('recruitLieutenant').disabled = true;
     state.money -= 20;
     runProgress('recruitLieutenantProgress', 3000, () => {
-        showLieutenantTypeSelection(choice => {
-            if (choice === 'face') { state.faces += 1; state.unlockedFaceExtort = true; }
-            else if (choice === 'fist') { state.fists += 1; }
-            else if (choice === 'brain') { state.brains += 1; }
+        showLieutenantTypeSelection(type => {
+            const id = Date.now() + Math.random();
+            state.leutenants.push({ id, type, busy: false });
+            if (type === 'face') state.unlocks.faceExtort = true;
+            if (type === 'brain') state.unlocks.buildIllicit = true;
             document.getElementById('recruitLieutenant').disabled = false;
+            renderLeutenants();
+            updateUI();
         });
     });
 }
 
 document.getElementById('recruitLieutenant').onclick = recruitLieutenant;
 
-function faceExtort() {
-    if (state.faces <= 0) return alert('Need a face lieutenant');
-    document.getElementById('faceExtort').disabled = true;
-    runProgress('faceExtortProgress', 4000, () => {
-        state.money += 15 * state.territory;
-        state.territory += 1;
-        if (state.patrol < state.territory) state.heat += 1;
-        document.getElementById('faceExtort').disabled = false;
-        state.unlockedBusiness = true;
-    });
-}
-
-document.getElementById('faceExtort').onclick = faceExtort;
 
 function buyBusiness() {
     if (state.money < 100) return alert('Not enough money');
@@ -224,25 +227,13 @@ function buyBusiness() {
     state.money -= 100;
     runProgress('buyBusinessProgress', 5000, () => {
         state.businesses += 1;
-        state.unlockedIllicit = true;
+        state.unlocks.buildIllicit = true;
         document.getElementById('buyBusiness').disabled = false;
     });
 }
 
 document.getElementById('buyBusiness').onclick = buyBusiness;
 
-function buildIllicit() {
-    if (state.businesses <= state.illicit) return alert("No available fronts");
-    if (state.brains <= 0) return alert("Need a brain lieutenant");
-    document.getElementById("buildIllicit").disabled = true;
-    state.brains -= 1;
-    runProgress("buildIllicitProgress", 4000, () => {
-        state.illicit += 1;
-        document.getElementById("buildIllicit").disabled = false;
-    });
-}
-
-document.getElementById("buildIllicit").onclick = buildIllicit;
 
 function payCops() {
     if (state.money < 50) return alert('Not enough money');
@@ -263,6 +254,7 @@ setInterval(() => {
     }
 }, 5000);
 
+renderLeutenants();
 updateUI();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- merge mooks and patrols so every mook automatically patrols
- replace boss/face actions with a generic lieutenant system
- implement per‑lieutenant tasks like extort, hire mook and build illicit
- introduce basic unlock infrastructure

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686dd944ba108326b2209fa82ff42675