### PR TITLE
Refactor lieutenants as individual units

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For a high level overview of the gameplay ideas, see [game-design.md](game-desig
 
 Open `index.html` in any modern web browser. No build step or server is required.
 
-You start with only the ability to extort with the boss. As you perform actions new options will unlock. Use the buttons to recruit mooks, assign them to patrols, recruit lieutenants and buy businesses. Progress bars show how long each action takes.
+You start with only the ability to extort with your first lieutenant. As you perform actions new options will unlock. Use the buttons to recruit mooks, assign them to patrols, recruit lieutenants and buy businesses. Progress bars show how long each action takes. Each lieutenant appears in a list where you can assign tasks individually.
 
 This prototype intentionally uses a very minimal user interface to focus purely on testing the core gameplay loop.
 

--- a/game-design.md
+++ b/game-design.md
@@ -15,11 +15,11 @@ This prototype explores a lightweight mafia management loop. Actions unlock prog
 - **Brain** – sets up illicit businesses behind purchased fronts.
 
 ## Gameplay Loop Example
-1. Extort with the boss to earn starting cash.
+1. Extort with the first lieutenant to earn starting cash.
 2. Recruit mooks and assign them to patrol to keep heat down.
-3. Hire lieutenants and choose their specialty.
-4. Use Face lieutenants to expand territory and earn more money.
-5. Buy a business and assign a Brain lieutenant to create an illicit operation.
+3. Hire lieutenants individually and choose their specialty.
+4. Assign Face lieutenants to extort and expand territory.
+5. Buy a business and assign a Brain lieutenant to create an illicit operation (the lieutenant is consumed).
 6. Balance money, territory, patrols and heat while gradually growing your empire.
 
 These notes are kept short on purpose – the goal is simply to track the prototype design as it evolves.

--- a/index.html
+++ b/index.html
@@ -23,15 +23,9 @@
 <div class="counter">Territory: <span id="territory">1</span> block(s)</div>
 <div class="counter">Heat: <span id="heat">0</span></div>
 <div class="counter">Businesses: <span id="businesses">0</span></div>
-<div class="counter">Faces: <span id="faces">0</span></div>
-<div class="counter">Fists: <span id="fists">0</span></div>
-<div class="counter">Brains: <span id="brains">0</span></div>
 <div class="counter">Illicit Businesses: <span id="illicit">0</span></div>
 <hr>
-<div class="action">
-    <button id="bossExtort">Extort with Boss</button>
-    <div id="bossExtortProgress" class="progress hidden"><div class="progress-bar"></div></div>
-</div>
+<div id="lieutenantList"></div>
 
 <div class="action">
     <button id="recruitMook" class="hidden">Recruit Mook ($5)</button>
@@ -53,18 +47,10 @@
     <button id="chooseBrain">Brain</button>
 </div>
 
-<div class="action">
-    <button id="faceExtort" class="hidden">Extort with Face</button>
-    <div id="faceExtortProgress" class="progress hidden"><div class="progress-bar"></div></div>
-</div>
 
 <div class="action">
     <button id="buyBusiness" class="hidden">Buy Business ($100)</button>
     <div id="buyBusinessProgress" class="progress hidden"><div class="progress-bar"></div></div>
-</div>
-<div class="action">
-    <button id="buildIllicit" class="hidden">Build Illicit Business</button>
-    <div id="buildIllicitProgress" class="progress hidden"><div class="progress-bar"></div></div>
 </div>
 
 <div class="action">
@@ -80,17 +66,15 @@ const state = {
     territory: 1,
     heat: 0,
     businesses: 0,
-    faces: 0,
-    fists: 0,
-    brains: 0,
     unlockedMook: false,
     unlockedPatrol: false,
     unlockedLieutenant: false,
-    unlockedFaceExtort: false,
     unlockedBusiness: false,
     illicit: 0,
     unlockedIllicit: false,
-};
+    lieutenants: [{id:1, type:'face', name:'First Lieutenant', first:true}],
+    nextLtId: 2,
+}; 
 
 function updateUI() {
     document.getElementById('money').textContent = state.money;
@@ -99,18 +83,13 @@ function updateUI() {
     document.getElementById('territory').textContent = state.territory;
     document.getElementById('heat').textContent = state.heat;
     document.getElementById('businesses').textContent = state.businesses;
-    document.getElementById('faces').textContent = state.faces;
-    document.getElementById('fists').textContent = state.fists;
-    document.getElementById('brains').textContent = state.brains;
 
     document.getElementById('illicit').textContent = state.illicit;
+    renderLieutenants();
     if (state.unlockedMook) document.getElementById('recruitMook').classList.remove('hidden');
     if (state.unlockedPatrol) document.getElementById('assignPatrol').classList.remove('hidden');
     if (state.unlockedLieutenant) document.getElementById('recruitLieutenant').classList.remove('hidden');
-    if (state.unlockedFaceExtort && state.faces > 0) document.getElementById('faceExtort').classList.remove('hidden');
     if (state.unlockedBusiness) document.getElementById('buyBusiness').classList.remove('hidden');
-    if (state.unlockedIllicit && state.businesses > state.illicit && state.brains > 0) document.getElementById("buildIllicit").classList.remove("hidden");
-    else document.getElementById("buildIllicit").classList.add("hidden");
     if (state.heat > 0) document.getElementById('payCops').classList.remove('hidden');
 }
 
@@ -151,16 +130,6 @@ function showLieutenantTypeSelection(callback) {
     document.getElementById('chooseBrain').onclick = () => choose('brain');
 }
 
-function bossExtort() {
-    document.getElementById('bossExtort').disabled = true;
-    runProgress('bossExtortProgress', 3000, () => {
-        state.money += 10;
-        state.unlockedMook = true;
-        document.getElementById('bossExtort').disabled = false;
-    });
-}
-
-document.getElementById('bossExtort').onclick = bossExtort;
 
 function recruitMook() {
     if (state.money < 5) return alert('Not enough money');
@@ -194,9 +163,8 @@ function recruitLieutenant() {
     state.money -= 20;
     runProgress('recruitLieutenantProgress', 3000, () => {
         showLieutenantTypeSelection(choice => {
-            if (choice === 'face') { state.faces += 1; state.unlockedFaceExtort = true; }
-            else if (choice === 'fist') { state.fists += 1; }
-            else if (choice === 'brain') { state.brains += 1; }
+            const lt = {id: state.nextLtId++, type: choice, name: 'Lieutenant ' + (state.nextLtId - 1)};
+            state.lieutenants.push(lt);
             document.getElementById('recruitLieutenant').disabled = false;
         });
     });
@@ -204,19 +172,63 @@ function recruitLieutenant() {
 
 document.getElementById('recruitLieutenant').onclick = recruitLieutenant;
 
-function faceExtort() {
-    if (state.faces <= 0) return alert('Need a face lieutenant');
-    document.getElementById('faceExtort').disabled = true;
-    runProgress('faceExtortProgress', 4000, () => {
-        state.money += 15 * state.territory;
-        state.territory += 1;
-        if (state.patrol < state.territory) state.heat += 1;
-        document.getElementById('faceExtort').disabled = false;
-        state.unlockedBusiness = true;
+function renderLieutenants() {
+    const list = document.getElementById('lieutenantList');
+    list.innerHTML = '';
+    state.lieutenants.forEach(lt => {
+        const row = document.createElement('div');
+        row.className = 'action';
+        const label = document.createElement('span');
+        label.textContent = `${lt.name} (${lt.type})`;
+        row.appendChild(label);
+        if (lt.type === 'face') {
+            const btn = document.createElement('button');
+            btn.textContent = 'Extort';
+            btn.disabled = lt.busy;
+            btn.onclick = () => lieutenantExtort(lt);
+            row.appendChild(btn);
+        } else if (lt.type === 'brain') {
+            const btn = document.createElement('button');
+            btn.textContent = 'Build Illicit';
+            btn.disabled = lt.busy || state.businesses <= state.illicit;
+            btn.onclick = () => lieutenantBuildIllicit(lt);
+            row.appendChild(btn);
+        }
+        const prog = document.createElement('div');
+        prog.id = `lt${lt.id}Progress`;
+        prog.className = 'progress hidden';
+        prog.innerHTML = '<div class="progress-bar"></div>';
+        row.appendChild(prog);
+        list.appendChild(row);
     });
 }
 
-document.getElementById('faceExtort').onclick = faceExtort;
+function lieutenantExtort(lt) {
+    lt.busy = true;
+    const duration = lt.first ? 3000 : 4000;
+    runProgress(`lt${lt.id}Progress`, duration, () => {
+        if (lt.first) {
+            state.money += 10;
+            state.unlockedMook = true;
+        } else {
+            state.money += 15 * state.territory;
+            state.territory += 1;
+            if (state.patrol < state.territory) state.heat += 1;
+            state.unlockedBusiness = true;
+        }
+        lt.busy = false;
+    });
+}
+
+function lieutenantBuildIllicit(lt) {
+    if (state.businesses <= state.illicit) return alert('No available fronts');
+    lt.busy = true;
+    runProgress(`lt${lt.id}Progress`, 4000, () => {
+        state.illicit += 1;
+        state.lieutenants = state.lieutenants.filter(l => l.id !== lt.id);
+    });
+}
+
 
 function buyBusiness() {
     if (state.money < 100) return alert('Not enough money');
@@ -231,18 +243,6 @@ function buyBusiness() {
 
 document.getElementById('buyBusiness').onclick = buyBusiness;
 
-function buildIllicit() {
-    if (state.businesses <= state.illicit) return alert("No available fronts");
-    if (state.brains <= 0) return alert("Need a brain lieutenant");
-    document.getElementById("buildIllicit").disabled = true;
-    state.brains -= 1;
-    runProgress("buildIllicitProgress", 4000, () => {
-        state.illicit += 1;
-        document.getElementById("buildIllicit").disabled = false;
-    });
-}
-
-document.getElementById("buildIllicit").onclick = buildIllicit;
 
 function payCops() {
     if (state.money < 50) return alert('Not enough money');


### PR DESCRIPTION
## Summary
- remove boss concept and start with a "first lieutenant"
- show a lieutenant list instead of type counters
- add per-lieutenant extort and illicit business actions
- update design notes and README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686dffa108448326b7eb0bd4b053d1c2