### PR TITLE
Remove manual patrol assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For a high level overview of the gameplay ideas, see [game-design.md](game-desig
 
 Open `index.html` in any modern web browser. No build step or server is required.
 
-You start with only the ability to extort with the boss. As you perform actions new options will unlock. Use the buttons to recruit mooks, assign them to patrols, recruit lieutenants and buy businesses. Progress bars show how long each action takes.
+You start with only the ability to extort with the boss. As you perform actions new options will unlock. Use the buttons to recruit mooks, recruit lieutenants and buy businesses. Recruited mooks automatically patrol your territory. Progress bars show how long each action takes.
 
 This prototype intentionally uses a very minimal user interface to focus purely on testing the core gameplay loop.
 

--- a/game-design.md
+++ b/game-design.md
@@ -16,7 +16,7 @@ This prototype explores a lightweight mafia management loop. Actions unlock prog
 
 ## Gameplay Loop Example
 1. Extort with the boss to earn starting cash.
-2. Recruit mooks and assign them to patrol to keep heat down.
+2. Recruit mooks (they automatically patrol your territory) to keep heat down.
 3. Hire lieutenants and choose their specialty.
 4. Use Face lieutenants to expand territory and earn more money.
 5. Buy a business and assign a Brain lieutenant to create an illicit operation.

--- a/index.html
+++ b/index.html
@@ -18,8 +18,7 @@
 <body>
 <h1>Mafia Manager Prototype</h1>
 <div class="counter">Money: $<span id="money">0</span></div>
-<div class="counter">Mooks: <span id="mooks">0</span></div>
-<div class="counter">Patrolling: <span id="patrol">0</span></div>
+<div class="counter">Mooks Patrolling: <span id="patrol">0</span></div>
 <div class="counter">Territory: <span id="territory">1</span> block(s)</div>
 <div class="counter">Heat: <span id="heat">0</span></div>
 <div class="counter">Businesses: <span id="businesses">0</span></div>
@@ -40,9 +39,6 @@
     <div id="recruitMookProgress" class="progress hidden"><div class="progress-bar"></div></div>
 </div>
 
-<div class="action">
-    <button id="assignPatrol" class="hidden">Assign Mook to Patrol</button>
-</div>
 
 <div class="action">
     <button id="recruitLieutenant" class="hidden">Recruit Lieutenant ($20)</button>
@@ -67,13 +63,11 @@
 <script>
 const state = {
     money: 0,
-    mooks: 0,
     patrol: 0,
     territory: 1,
     heat: 0,
     businesses: 0,
     unlockedMook: false,
-    unlockedPatrol: false,
     unlockedLieutenant: false,
     unlockedBusiness: false,
     illicit: 0,
@@ -84,7 +78,6 @@ const state = {
 
 function updateUI() {
     document.getElementById('money').textContent = state.money;
-    document.getElementById('mooks').textContent = state.mooks;
     document.getElementById('patrol').textContent = state.patrol;
     document.getElementById('territory').textContent = state.territory;
     document.getElementById('heat').textContent = state.heat;
@@ -98,7 +91,6 @@ function updateUI() {
 
     document.getElementById('illicit').textContent = state.illicit;
     if (state.unlockedMook) document.getElementById('recruitMook').classList.remove('hidden');
-    if (state.unlockedPatrol) document.getElementById('assignPatrol').classList.remove('hidden');
     if (state.unlockedLieutenant) document.getElementById('recruitLieutenant').classList.remove('hidden');
     if (state.unlockedBusiness) document.getElementById('buyBusiness').classList.remove('hidden');
     if (state.heat > 0) document.getElementById('payCops').classList.remove('hidden');
@@ -205,8 +197,7 @@ function recruitMook() {
     document.getElementById('recruitMook').disabled = true;
     state.money -= 5;
     runProgress(document.getElementById('recruitMookProgress'), 2000, () => {
-        state.mooks += 1;
-        state.unlockedPatrol = true;
+        state.patrol += 1;
         state.unlockedLieutenant = true;
         document.getElementById('recruitMook').disabled = false;
     });
@@ -214,17 +205,6 @@ function recruitMook() {
 
 document.getElementById('recruitMook').onclick = recruitMook;
 
-function assignPatrol() {
-    if (state.mooks <= 0) return alert('No available mooks');
-    state.mooks -= 1;
-    state.patrol += 1;
-    if (state.patrol < state.territory) {
-        state.heat += 1; // not enough patrol, heat rises
-    }
-    updateUI();
-}
-
-document.getElementById('assignPatrol').onclick = assignPatrol;
 
 function recruitLieutenant() {
     if (state.money < 20) return alert('Not enough money');


### PR DESCRIPTION
## Summary
- show only `Mooks Patrolling` counter
- remove manual patrol assignment UI and state handling
- recruit mooks now automatically add to patrol
- update docs to reflect simplified patrol system

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686fd41803788326bbcb7c1fd4f34e45