### PR TITLE
Enable lieutenants to recruit mooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For a high level overview of the gameplay ideas, see [game-design.md](game-desig
 
 Open `index.html` in any modern web browser. No build step or server is required.
 
-You start with only the ability to extort with the boss. As you perform actions new options will unlock. Use the buttons to recruit mooks, recruit lieutenants and buy businesses. Recruited mooks automatically patrol your territory. Progress bars show how long each action takes.
+You start with only the ability to extort with the boss. As you perform actions new options will unlock. Use the buttons to recruit mooks, recruit lieutenants and buy businesses. Recruited mooks automatically patrol your territory. Lieutenants can also recruit mooks on their own, similar to how they extort. Progress bars show how long each action takes.
 
 This prototype intentionally uses a very minimal user interface to focus purely on testing the core gameplay loop.
 

--- a/game-design.md
+++ b/game-design.md
@@ -13,6 +13,7 @@ This prototype explores a lightweight mafia management loop. Actions unlock prog
 - **Face** – used to extort surrounding blocks, expanding territory and generating cash.
 - **Fist** – keeps unruly businesses in line when patrols are thin (not yet implemented).
 - **Brain** – sets up illicit businesses behind purchased fronts.
+- Lieutenants can also recruit additional mooks to expand patrol coverage.
 
 ## Gameplay Loop Example
 1. Extort with the boss to earn starting cash.

--- a/index.html
+++ b/index.html
@@ -146,11 +146,29 @@ function renderLieutenants() {
             prog.innerHTML = '<div class="progress-bar"></div>';
             row.appendChild(btn);
             row.appendChild(prog);
+
+            const recruitRow = document.createElement('div');
+            recruitRow.className = 'action';
+            const recruitBtn = document.createElement('button');
+            const recruitProg = document.createElement('div');
+            recruitProg.className = 'progress hidden';
+            recruitProg.innerHTML = '<div class="progress-bar"></div>';
+            recruitRow.appendChild(recruitBtn);
+            recruitRow.appendChild(recruitProg);
+
             lt.element = row;
             lt.button = btn;
             lt.progress = prog;
-            if (lt.type === 'face') faceDiv.appendChild(row);
-            else if (lt.type === 'brain') brainDiv.appendChild(row);
+            lt.recruitElement = recruitRow;
+            lt.recruitButton = recruitBtn;
+            lt.recruitProgress = recruitProg;
+            if (lt.type === 'face') {
+                faceDiv.appendChild(row);
+                faceDiv.appendChild(recruitRow);
+            } else if (lt.type === 'brain') {
+                brainDiv.appendChild(row);
+                brainDiv.appendChild(recruitRow);
+            }
             btn.onclick = () => {
                 if (lt.busy) return;
                 if (lt.type === 'brain' && state.businesses <= state.illicit) return alert('No available fronts');
@@ -170,13 +188,32 @@ function renderLieutenants() {
                     btn.disabled = false;
                 });
             };
+
+            recruitBtn.onclick = () => {
+                if (lt.busy) return;
+                if (state.money < 5) return alert('Not enough money');
+                lt.busy = true;
+                recruitBtn.disabled = true;
+                state.money -= 5;
+                runProgress(recruitProg, 2000, () => {
+                    state.patrol += 1;
+                    state.unlockedLieutenant = true;
+                    lt.busy = false;
+                    recruitBtn.disabled = false;
+                    updateUI();
+                });
+            };
         }
         if (lt.type === 'face') {
             lt.button.textContent = `Face #${lt.id} Extort`;
             lt.button.disabled = lt.busy;
+            lt.recruitButton.textContent = `Face #${lt.id} Recruit Mook`;
+            lt.recruitButton.disabled = lt.busy;
         } else if (lt.type === 'brain') {
             lt.button.textContent = `Brain #${lt.id} Build Illicit`;
             lt.button.disabled = lt.busy || !state.unlockedIllicit;
+            lt.recruitButton.textContent = `Lt #${lt.id} Recruit Mook`;
+            lt.recruitButton.disabled = lt.busy;
         }
     });
 }


### PR DESCRIPTION
## Summary
- add a recruit option for each lieutenant
- document lieutenant recruiting in README and design notes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686fdee51088832699266099415f3dd3