### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,10 +13,15 @@
         .hidden { display: none; }
         .progress { width: 200px; background: #ccc; height: 16px; margin: 0; position: relative; }
         .progress-bar { height: 100%; width: 0%; background: #4caf50; transition: width 0.1s linear; }
+        body.dark { background: #121212; color: #eee; }
+        body.dark button { background: #333; color: #eee; }
+        body.dark .progress { background: #555; }
+        body.dark .progress-bar { background: #81c784; }
     </style>
 </head>
 <body>
 <h1>Mafia Manager Prototype</h1>
+<button id="toggleDark">Dark Mode</button>
 <div class="counter">Time: <span id="time">0</span>s</div>
 <div class="counter">Money: $<span id="money">0</span></div>
 <div class="counter">Mooks Patrolling: <span id="patrol">0</span></div>
@@ -76,6 +81,19 @@ const state = {
     lieutenants: [],
     nextLtId: 1,
 };
+
+function applyDarkMode(enabled) {
+    document.body.classList.toggle('dark', enabled);
+    localStorage.setItem('darkMode', enabled ? 'true' : 'false');
+    document.getElementById('toggleDark').textContent = enabled ? 'Light Mode' : 'Dark Mode';
+}
+
+function toggleDarkMode() {
+    applyDarkMode(!document.body.classList.contains('dark'));
+}
+
+applyDarkMode(localStorage.getItem('darkMode') === 'true');
+document.getElementById('toggleDark').onclick = toggleDarkMode;
 
 function updateUI() {
     document.getElementById('time').textContent = state.time;


### PR DESCRIPTION
## Summary
- introduce dark mode styles
- add toggle button to switch between light and dark modes
- remember user preference via localStorage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870a1218a448326b869935dd05f0484