### PR TITLE
Lieutenant specializations for recruiting and business

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,18 +30,9 @@
 <hr>
 <div id="bossContainer"></div>
 <div id="facesContainer"></div>
+<div id="fistsContainer"></div>
 <div id="brainsContainer"></div>
 
-<div class="action">
-    <button id="recruitMook" class="hidden">Recruit Mook ($5)</button>
-    <div id="recruitMookProgress" class="progress hidden"><div class="progress-bar"></div></div>
-</div>
-
-
-<div class="action">
-    <button id="recruitLieutenant" class="hidden">Recruit Lieutenant ($20)</button>
-    <div id="recruitLieutenantProgress" class="progress hidden"><div class="progress-bar"></div></div>
-</div>
 <div id="lieutenantChoice" class="hidden">
     <p>Select lieutenant type:</p>
     <button id="chooseFace">Face</button>
@@ -49,10 +40,6 @@
     <button id="chooseBrain">Brain</button>
 </div>
 
-<div class="action">
-    <button id="buyBusiness" class="hidden">Buy Business ($100)</button>
-    <div id="buyBusinessProgress" class="progress hidden"><div class="progress-bar"></div></div>
-</div>
 <div class="action">
     <button id="payCops" class="hidden">Pay Off Cops ($50)</button>
     <div id="payCopsProgress" class="progress hidden"><div class="progress-bar"></div></div>
@@ -67,7 +54,6 @@ const state = {
     heat: 0,
     heatProgress: 0,
     businesses: 0,
-    unlockedMook: false,
     unlockedLieutenant: false,
     unlockedBusiness: false,
     illicit: 0,
@@ -93,9 +79,6 @@ function updateUI() {
     document.getElementById('brains').textContent = brains;
 
     document.getElementById('illicit').textContent = state.illicit;
-    if (state.unlockedMook) document.getElementById('recruitMook').classList.remove('hidden');
-    if (state.unlockedLieutenant) document.getElementById('recruitLieutenant').classList.remove('hidden');
-    if (state.unlockedBusiness) document.getElementById('buyBusiness').classList.remove('hidden');
     if (state.heat > 0) document.getElementById('payCops').classList.remove('hidden');
     renderBoss();
     renderLieutenants();
@@ -159,12 +142,26 @@ function renderBoss() {
         recruitProg.className = 'progress hidden';
         recruitProg.innerHTML = '<div class="progress-bar"></div>';
 
+        const hireBtn = document.createElement('button');
+        const hireProg = document.createElement('div');
+        hireProg.className = 'progress hidden';
+        hireProg.innerHTML = '<div class="progress-bar"></div>';
+
+        const buyBtn = document.createElement('button');
+        const buyProg = document.createElement('div');
+        buyProg.className = 'progress hidden';
+        buyProg.innerHTML = '<div class="progress-bar"></div>';
+
         row.appendChild(extortBtn);
         row.appendChild(extortProg);
         row.appendChild(illicitBtn);
         row.appendChild(illicitProg);
         row.appendChild(recruitBtn);
         row.appendChild(recruitProg);
+        row.appendChild(hireBtn);
+        row.appendChild(hireProg);
+        row.appendChild(buyBtn);
+        row.appendChild(buyProg);
 
         boss.element = row;
         boss.extortButton = extortBtn;
@@ -173,6 +170,10 @@ function renderBoss() {
         boss.illicitProgress = illicitProg;
         boss.recruitButton = recruitBtn;
         boss.recruitProgress = recruitProg;
+        boss.hireButton = hireBtn;
+        boss.hireProgress = hireProg;
+        boss.buyButton = buyBtn;
+        boss.buyProgress = buyProg;
 
         container.appendChild(row);
 
@@ -182,15 +183,22 @@ function renderBoss() {
             extortBtn.disabled = true;
             illicitBtn.disabled = true;
             recruitBtn.disabled = true;
+            hireBtn.disabled = true;
+            buyBtn.disabled = true;
+            hireBtn.disabled = true;
+            buyBtn.disabled = true;
+            hireBtn.disabled = true;
+            buyBtn.disabled = true;
             runProgress(extortProg, 3000, () => {
                 state.money += 15 * state.territory;
                 state.territory += 1;
                 state.unlockedBusiness = true;
-                state.unlockedMook = true;
                 boss.busy = false;
                 extortBtn.disabled = false;
                 illicitBtn.disabled = false;
                 recruitBtn.disabled = false;
+                hireBtn.disabled = false;
+                buyBtn.disabled = false;
             });
         };
 
@@ -207,6 +215,8 @@ function renderBoss() {
                 extortBtn.disabled = false;
                 illicitBtn.disabled = false;
                 recruitBtn.disabled = false;
+                hireBtn.disabled = false;
+                buyBtn.disabled = false;
             });
         };
 
@@ -217,6 +227,8 @@ function renderBoss() {
             extortBtn.disabled = true;
             illicitBtn.disabled = true;
             recruitBtn.disabled = true;
+            hireBtn.disabled = true;
+            buyBtn.disabled = true;
             state.money -= 5;
             runProgress(recruitProg, 2000, () => {
                 state.patrol += 1;
@@ -225,6 +237,55 @@ function renderBoss() {
                 extortBtn.disabled = false;
                 illicitBtn.disabled = false;
                 recruitBtn.disabled = false;
+                hireBtn.disabled = false;
+                buyBtn.disabled = false;
+            });
+        };
+
+        hireBtn.onclick = () => {
+            if (boss.busy || !state.unlockedLieutenant) return;
+            if (state.money < 20) return alert('Not enough money');
+            boss.busy = true;
+            extortBtn.disabled = true;
+            illicitBtn.disabled = true;
+            recruitBtn.disabled = true;
+            hireBtn.disabled = true;
+            buyBtn.disabled = true;
+            state.money -= 20;
+            runProgress(hireProg, 3000, () => {
+                showLieutenantTypeSelection(choice => {
+                    const lt = { id: state.nextLtId++, type: choice, busy: false };
+                    state.lieutenants.push(lt);
+                    boss.busy = false;
+                    extortBtn.disabled = false;
+                    illicitBtn.disabled = false;
+                    recruitBtn.disabled = false;
+                    hireBtn.disabled = false;
+                    buyBtn.disabled = false;
+                    updateUI();
+                });
+            });
+        };
+
+        buyBtn.onclick = () => {
+            if (boss.busy || !state.unlockedBusiness) return;
+            if (state.money < 100) return alert('Not enough money');
+            boss.busy = true;
+            extortBtn.disabled = true;
+            illicitBtn.disabled = true;
+            recruitBtn.disabled = true;
+            hireBtn.disabled = true;
+            buyBtn.disabled = true;
+            state.money -= 100;
+            runProgress(buyProg, 5000, () => {
+                state.businesses += 1;
+                state.unlockedIllicit = true;
+                boss.busy = false;
+                extortBtn.disabled = false;
+                illicitBtn.disabled = false;
+                recruitBtn.disabled = false;
+                hireBtn.disabled = false;
+                buyBtn.disabled = false;
             });
         };
     }
@@ -235,10 +296,17 @@ function renderBoss() {
     boss.illicitButton.disabled = boss.busy || !state.unlockedIllicit;
     boss.recruitButton.textContent = 'Boss Recruit Mook';
     boss.recruitButton.disabled = boss.busy;
+    boss.hireButton.textContent = 'Boss Hire Lt';
+    boss.hireButton.disabled = boss.busy || !state.unlockedLieutenant;
+    boss.hireButton.classList.toggle('hidden', !state.unlockedLieutenant);
+    boss.buyButton.textContent = 'Boss Buy Business';
+    boss.buyButton.disabled = boss.busy || !state.unlockedBusiness;
+    boss.buyButton.classList.toggle('hidden', !state.unlockedBusiness);
 }
 
 function renderLieutenants() {
     const faceDiv = document.getElementById('facesContainer');
+    const fistDiv = document.getElementById('fistsContainer');
     const brainDiv = document.getElementById('brainsContainer');
     state.lieutenants.forEach(lt => {
         if (!lt.element) {
@@ -250,15 +318,18 @@ function renderLieutenants() {
             prog.className = 'progress hidden';
             prog.innerHTML = '<div class="progress-bar"></div>';
 
-            const recruitBtn = document.createElement('button');
-            const recruitProg = document.createElement('div');
-            recruitProg.className = 'progress hidden';
-            recruitProg.innerHTML = '<div class="progress-bar"></div>';
-
             row.appendChild(btn);
             row.appendChild(prog);
-            row.appendChild(recruitBtn);
-            row.appendChild(recruitProg);
+            let recruitBtn;
+            let recruitProg;
+            if (lt.type !== 'fist') {
+                recruitBtn = document.createElement('button');
+                recruitProg = document.createElement('div');
+                recruitProg.className = 'progress hidden';
+                recruitProg.innerHTML = '<div class="progress-bar"></div>';
+                row.appendChild(recruitBtn);
+                row.appendChild(recruitProg);
+            }
 
             lt.element = row;
             lt.button = btn;
@@ -267,6 +338,7 @@ function renderLieutenants() {
             lt.recruitProgress = recruitProg;
 
             if (lt.type === 'face') faceDiv.appendChild(row);
+            else if (lt.type === 'fist') fistDiv.appendChild(row);
             else if (lt.type === 'brain') brainDiv.appendChild(row);
 
             btn.onclick = () => {
@@ -274,8 +346,10 @@ function renderLieutenants() {
                 if (lt.type === 'brain' && state.businesses <= state.illicit) return alert('No available fronts');
                 lt.busy = true;
                 btn.disabled = true;
-                recruitBtn.disabled = true;
-                const duration = lt.type === 'face' ? 4000 : 4000;
+                if (recruitBtn) recruitBtn.disabled = true;
+                let duration = 2000;
+                if (lt.type === 'face') duration = 4000;
+                if (lt.type === 'brain') duration = 4000;
                 runProgress(prog, duration, () => {
                     if (lt.type === 'face') {
                         state.money += 15 * state.territory;
@@ -283,84 +357,78 @@ function renderLieutenants() {
                         state.unlockedBusiness = true;
                     } else if (lt.type === 'brain') {
                         state.illicit += 1;
+                    } else if (lt.type === 'fist') {
+                        state.patrol += 1;
+                        state.unlockedLieutenant = true;
                     }
                     lt.busy = false;
                     btn.disabled = false;
-                    recruitBtn.disabled = false;
+                    if (recruitBtn) recruitBtn.disabled = false;
                 });
             };
 
-            recruitBtn.onclick = () => {
-                if (lt.busy) return;
-                if (state.money < 5) return alert('Not enough money');
-                lt.busy = true;
-                recruitBtn.disabled = true;
-                btn.disabled = true;
-                state.money -= 5;
-                runProgress(recruitProg, 2000, () => {
-                    state.patrol += 1;
-                    state.unlockedLieutenant = true;
-                    lt.busy = false;
-                    recruitBtn.disabled = false;
-                    btn.disabled = false;
-                });
-            };
+            if (recruitBtn) {
+                recruitBtn.onclick = () => {
+                    if (lt.busy) return;
+                    if (lt.type === 'face') {
+                        if (!state.unlockedLieutenant) return;
+                        if (state.money < 20) return alert('Not enough money');
+                        lt.busy = true;
+                        recruitBtn.disabled = true;
+                        btn.disabled = true;
+                        state.money -= 20;
+                        runProgress(recruitProg, 3000, () => {
+                            showLieutenantTypeSelection(choice => {
+                                const n = { id: state.nextLtId++, type: choice, busy: false };
+                                state.lieutenants.push(n);
+                                lt.busy = false;
+                                recruitBtn.disabled = false;
+                                btn.disabled = false;
+                                updateUI();
+                            });
+                        });
+                    } else if (lt.type === 'brain') {
+                        if (!state.unlockedBusiness) return;
+                        if (state.money < 100) return alert('Not enough money');
+                        lt.busy = true;
+                        recruitBtn.disabled = true;
+                        btn.disabled = true;
+                        state.money -= 100;
+                        runProgress(recruitProg, 5000, () => {
+                            state.businesses += 1;
+                            state.unlockedIllicit = true;
+                            lt.busy = false;
+                            recruitBtn.disabled = false;
+                            btn.disabled = false;
+                        });
+                    }
+                };
+            }
         }
         if (lt.type === 'face') {
             lt.button.textContent = `Face #${lt.id} Extort`;
             lt.button.disabled = lt.busy;
+            if (lt.recruitButton) {
+                lt.recruitButton.textContent = `Face #${lt.id} Hire Lt`;
+                lt.recruitButton.disabled = lt.busy || !state.unlockedLieutenant;
+                lt.recruitButton.classList.toggle('hidden', !state.unlockedLieutenant);
+            }
         } else if (lt.type === 'brain') {
             lt.button.textContent = `Brain #${lt.id} Build Illicit`;
             lt.button.disabled = lt.busy || !state.unlockedIllicit;
+            if (lt.recruitButton) {
+                lt.recruitButton.textContent = `Brain #${lt.id} Buy Business`;
+                lt.recruitButton.disabled = lt.busy || !state.unlockedBusiness;
+                lt.recruitButton.classList.toggle('hidden', !state.unlockedBusiness);
+            }
+        } else if (lt.type === 'fist') {
+            lt.button.textContent = `Fist #${lt.id} Recruit Mook`;
+            lt.button.disabled = lt.busy;
         }
-        lt.recruitButton.textContent = `Lt #${lt.id} Recruit Mook`;
-        lt.recruitButton.disabled = lt.busy;
     });
 }
 
 
-function recruitMook() {
-    if (state.money < 5) return alert('Not enough money');
-    document.getElementById('recruitMook').disabled = true;
-    state.money -= 5;
-    runProgress(document.getElementById('recruitMookProgress'), 2000, () => {
-        state.patrol += 1;
-        state.unlockedLieutenant = true;
-        document.getElementById('recruitMook').disabled = false;
-    });
-}
-
-document.getElementById('recruitMook').onclick = recruitMook;
-
-
-function recruitLieutenant() {
-    if (state.money < 20) return alert('Not enough money');
-    document.getElementById('recruitLieutenant').disabled = true;
-    state.money -= 20;
-    runProgress(document.getElementById('recruitLieutenantProgress'), 3000, () => {
-        showLieutenantTypeSelection(choice => {
-            const lt = { id: state.nextLtId++, type: choice, busy: false };
-            state.lieutenants.push(lt);
-            document.getElementById('recruitLieutenant').disabled = false;
-            updateUI();
-        });
-    });
-}
-
-document.getElementById('recruitLieutenant').onclick = recruitLieutenant;
-
-function buyBusiness() {
-    if (state.money < 100) return alert('Not enough money');
-    document.getElementById('buyBusiness').disabled = true;
-    state.money -= 100;
-    runProgress(document.getElementById('buyBusinessProgress'), 5000, () => {
-        state.businesses += 1;
-        state.unlockedIllicit = true;
-        document.getElementById('buyBusiness').disabled = false;
-    });
-}
-
-document.getElementById('buyBusiness').onclick = buyBusiness;
 
 
 function payCops() {


### PR DESCRIPTION
## Summary
- add separate container for fist lieutenants
- remove global recruit and buy buttons
- let the boss recruit lieutenants and buy businesses
- give faces the hire ability, brains business purchasing, and fists mook recruiting

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6870a2236ac48326b7f1ed17dad2c96d