### PR TITLE
Improve progress bar layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,8 @@
       padding: 20px;
       background: var(--bg);
       color: var(--text);
+      max-width: 800px;
+      margin: 0 auto;
     }
     .counter { margin: 4px 0; }
 
@@ -84,7 +86,7 @@
       margin: 0;
     }
     .action .progress {
-      margin-left: 8px;
+      margin-left: auto;
     }
     </style>
 </head>
@@ -211,52 +213,29 @@ function renderBoss() {
         row.className = 'action';
 
         const extortBtn = document.createElement('button');
-        const extortProg = document.createElement('div');
-        extortProg.className = 'progress hidden';
-        extortProg.innerHTML = '<div class="progress-bar"></div>';
-
         const illicitBtn = document.createElement('button');
-        const illicitProg = document.createElement('div');
-        illicitProg.className = 'progress hidden';
-        illicitProg.innerHTML = '<div class="progress-bar"></div>';
-
         const recruitBtn = document.createElement('button');
-        const recruitProg = document.createElement('div');
-        recruitProg.className = 'progress hidden';
-        recruitProg.innerHTML = '<div class="progress-bar"></div>';
-
         const hireBtn = document.createElement('button');
-        const hireProg = document.createElement('div');
-        hireProg.className = 'progress hidden';
-        hireProg.innerHTML = '<div class="progress-bar"></div>';
-
         const businessBtn = document.createElement('button');
-        const businessProg = document.createElement('div');
-        businessProg.className = 'progress hidden';
-        businessProg.innerHTML = '<div class="progress-bar"></div>';
+
+        const progress = document.createElement('div');
+        progress.className = 'progress hidden';
+        progress.innerHTML = '<div class="progress-bar"></div>';
 
         row.appendChild(extortBtn);
-        row.appendChild(extortProg);
         row.appendChild(illicitBtn);
-        row.appendChild(illicitProg);
         row.appendChild(recruitBtn);
-        row.appendChild(recruitProg);
         row.appendChild(hireBtn);
-        row.appendChild(hireProg);
         row.appendChild(businessBtn);
-        row.appendChild(businessProg);
+        row.appendChild(progress);
 
         boss.element = row;
         boss.extortButton = extortBtn;
-        boss.extortProgress = extortProg;
         boss.illicitButton = illicitBtn;
-        boss.illicitProgress = illicitProg;
         boss.recruitButton = recruitBtn;
-        boss.recruitProgress = recruitProg;
         boss.hireButton = hireBtn;
-        boss.hireProgress = hireProg;
         boss.businessButton = businessBtn;
-        boss.businessProgress = businessProg;
+        boss.progress = progress;
 
         container.appendChild(row);
 
@@ -268,7 +247,7 @@ function renderBoss() {
             recruitBtn.disabled = true;
             hireBtn.disabled = true;
             businessBtn.disabled = true;
-            runProgress(extortProg, 3000, () => {
+            runProgress(progress, 3000, () => {
                 state.money += 15 * state.territory;
                 state.territory += 1;
                 state.unlockedBusiness = true;
@@ -291,7 +270,7 @@ function renderBoss() {
             recruitBtn.disabled = true;
             hireBtn.disabled = true;
             businessBtn.disabled = true;
-            runProgress(illicitProg, 4000, () => {
+            runProgress(progress, 4000, () => {
                 state.illicit += 1;
                 boss.busy = false;
                 extortBtn.disabled = false;
@@ -312,7 +291,7 @@ function renderBoss() {
             hireBtn.disabled = true;
             businessBtn.disabled = true;
             state.money -= 5;
-            runProgress(recruitProg, 2000, () => {
+            runProgress(progress, 2000, () => {
                 state.patrol += 1;
                 state.unlockedLieutenant = true;
                 boss.busy = false;
@@ -335,7 +314,7 @@ function renderBoss() {
             hireBtn.disabled = true;
             businessBtn.disabled = true;
             state.money -= 20;
-            runProgress(hireProg, 3000, () => {
+            runProgress(progress, 3000, () => {
                 showLieutenantTypeSelection(choice => {
                     const lt = { id: state.nextLtId++, type: choice, busy: false };
                     state.lieutenants.push(lt);
@@ -361,7 +340,7 @@ function renderBoss() {
             hireBtn.disabled = true;
             businessBtn.disabled = true;
             state.money -= 100;
-            runProgress(businessProg, 5000, () => {
+            runProgress(progress, 5000, () => {
                 state.businesses += 1;
                 state.unlockedIllicit = true;
                 boss.busy = false;
@@ -401,20 +380,15 @@ function renderLieutenants() {
             prog.innerHTML = '<div class="progress-bar"></div>';
 
             const auxBtn = document.createElement('button');
-            const auxProg = document.createElement('div');
-            auxProg.className = 'progress hidden';
-            auxProg.innerHTML = '<div class="progress-bar"></div>';
 
             row.appendChild(btn);
-            row.appendChild(prog);
             row.appendChild(auxBtn);
-            row.appendChild(auxProg);
+            row.appendChild(prog);
 
             lt.element = row;
             lt.button = btn;
             lt.progress = prog;
             lt.auxButton = auxBtn;
-            lt.auxProgress = auxProg;
 
             if (lt.type === 'face') faceDiv.appendChild(row);
             else if (lt.type === 'brain') brainDiv.appendChild(row);
@@ -444,7 +418,7 @@ function renderLieutenants() {
                     auxBtn.disabled = true;
                     btn.disabled = true;
                     state.money -= 20;
-                    runProgress(auxProg, 3000, () => {
+                    runProgress(prog, 3000, () => {
                         showLieutenantTypeSelection(choice => {
                             const n = { id: state.nextLtId++, type: choice, busy: false };
                             state.lieutenants.push(n);
@@ -478,7 +452,7 @@ function renderLieutenants() {
                     auxBtn.disabled = true;
                     btn.disabled = true;
                     state.money -= 100;
-                    runProgress(auxProg, 5000, () => {
+                    runProgress(prog, 5000, () => {
                         state.businesses += 1;
                         state.unlockedIllicit = true;
                         lt.busy = false;
@@ -488,7 +462,6 @@ function renderLieutenants() {
                 };
             } else if (lt.type === 'fist') {
                 auxBtn.style.display = 'none';
-                auxProg.style.display = 'none';
                 btn.onclick = () => {
                     if (lt.busy) return;
                     if (state.money < 5) return alert('Not enough money');


### PR DESCRIPTION
## Summary
- center main content with max width
- move gangster progress bars to the far right
- use a single progress bar per gangster so buttons don't shift

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6874970ade908326a87d4ab01881ac3f