### PR TITLE
Align progress bars and center layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,8 @@
       padding: 20px;
       background: var(--bg);
       color: var(--text);
+      max-width: 800px;
+      margin: 0 auto;
     }
     .counter { margin: 4px 0; }
 
@@ -79,12 +81,15 @@
       display: flex;
       align-items: center;
       margin: 4px 0;
+      position: relative;
+      padding-right: 208px;
     }
     .action button {
       margin: 0;
     }
     .action .progress {
-      margin-left: 8px;
+      position: absolute;
+      right: 0;
     }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- keep page centered within a max width
- reserve space for progress bars so buttons no longer shift
- move progress bars to the far right of each gangster row

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_6874970ade908326a87d4ab01881ac3f