### PR TITLE
Implement disagreeable business owners

### DIFF
--- a/game-design.md
+++ b/game-design.md
@@ -22,5 +22,6 @@ This prototype explores a lightweight mafia management loop. Actions unlock prog
 4. Use Face gangsters to expand territory and earn more money.
 5. Have Brains purchase businesses and then create illicit operations behind them. When building an illicit operation you can select from counterfeiting money, producing drugs, running illegal gambling or fencing stolen goods.
 6. Balance money, territory, patrols and heat while gradually growing your empire.
+7. Occasionally an extorted business owner may be disagreeable. They refuse to pay, increase heat and are tracked by a new "disagreeable owners" counter.
 
 These notes are kept short on purpose – the goal is simply to track the prototype design as it evolves.

--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@
 <div class="counter">Enforcers Patrolling: <span id="patrol">0</span></div>
 <div class="counter">Territory: <span id="territory">0</span> block(s)</div>
 <div class="counter">Heat: <span id="heat">0</span> (<span id="heatProgress">0</span>/10)</div>
+<div class="counter">Disagreeable Owners: <span id="disagreeableOwners">0</span></div>
 <div class="counter">Businesses: <span id="businesses">0</span></div>
 <div class="counter">Faces: <span id="faces">0</span></div>
 <div class="counter">Fists: <span id="fists">0</span></div>
@@ -146,6 +147,7 @@ const state = {
     territory: 0,
     heat: 0,
     heatProgress: 0,
+    disagreeableOwners: 0,
     businesses: 0,
     unlockedEnforcer: false,
     unlockedGangster: false,
@@ -158,6 +160,8 @@ const state = {
     gangsters: [],
     nextGangId: 1,
 };
+
+const DISAGREEABLE_CHANCE = 0.2;
 
 const darkToggle = document.getElementById('darkToggle');
 const storedDark = localStorage.getItem('dark') === '1';
@@ -175,6 +179,7 @@ function updateUI() {
     document.getElementById('territory').textContent = state.territory;
     document.getElementById('heat').textContent = state.heat;
     document.getElementById('heatProgress').textContent = state.heatProgress;
+    document.getElementById('disagreeableOwners').textContent = state.disagreeableOwners;
     document.getElementById('businesses').textContent = state.businesses;
     const available = state.businesses - state.illicit - state.illicitProgress;
     document.getElementById('availableFronts').textContent = available;
@@ -317,7 +322,12 @@ function renderBoss() {
             hireBtn.disabled = true;
             businessBtn.disabled = true;
             runProgress(extortProg, 3000, () => {
-                state.money += 15 * state.territory;
+                if (Math.random() < DISAGREEABLE_CHANCE) {
+                    state.disagreeableOwners += 1;
+                    state.heat += 1;
+                } else {
+                    state.money += 15 * state.territory;
+                }
                 state.territory += 1;
                 state.unlockedBusiness = true;
                 state.unlockedEnforcer = true;
@@ -483,7 +493,12 @@ function renderGangsters() {
                     btn.disabled = true;
                     auxBtn.disabled = true;
                     runProgress(prog, 4000, () => {
-                        state.money += 15 * state.territory;
+                        if (Math.random() < DISAGREEABLE_CHANCE) {
+                            state.disagreeableOwners += 1;
+                            state.heat += 1;
+                        } else {
+                            state.money += 15 * state.territory;
+                        }
                         state.territory += 1;
                         state.unlockedBusiness = true;
                         g.busy = false;


### PR DESCRIPTION
## Summary
- show a new counter for disagreeable owners
- track disagreeable owners in game state
- add random chance during extortion to run into a disagreeable owner
- disagreeable owners add heat and provide no income
- document the mechanic in `game-design.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687713a2018c83268a02dddf14e7f863