### PR TITLE
Implement fear mechanic with new Fist ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For a high level overview of the gameplay ideas, see [game-design.md](game-desig
 
 Open `index.html` in any modern web browser. No build step or server is required.
 
-You start with only the ability to extort with the boss. Extortion now claims a block of territory while providing a small cash boost. As you perform actions new options will unlock. Faces can recruit additional gangsters, brains buy new businesses and fists bring in more enforcers or raid rival businesses for fast money at the cost of heat. The boss can perform any of these tasks. Recruited enforcers automatically patrol your territory. Progress bars show how long each action takes.
+You start with only the ability to extort with the boss. Extortion now claims a block of territory while providing a small cash boost. As you perform actions new options will unlock. Faces can recruit additional gangsters, brains buy new businesses and fists bring in more enforcers or raid rival businesses for fast money at the cost of heat. Fists can also intimidate disagreeable owners into paying protection, raising a new **fear** meter. The boss can perform any of these tasks. Recruited enforcers automatically patrol your territory. Progress bars show how long each action takes.
 When establishing an illicit business you are prompted to choose between money counterfeiting, drug production, illegal gambling or fencing operations.
 
 This prototype intentionally uses a very minimal user interface to focus purely on testing the core gameplay loop.

--- a/game-design.md
+++ b/game-design.md
@@ -9,10 +9,12 @@ This prototype explores a lightweight mafia management loop. Actions unlock prog
 - **Heat** – unwanted attention from law enforcement. Can be reduced by paying off cops.
 - **Businesses** – legitimate fronts that can host illicit operations.
 - **Available Fronts** – businesses not yet hosting illicit operations.
+- **Fear** – represents how cowed local businesses are. Certain actions raise it and may unlock future bonuses.
 
 ## Gangsters
 - **Face** – used to extort surrounding blocks, expanding territory and generating cash.
 - **Fist** – recruits enforcers and can raid rival businesses for quick cash at the cost of heat.
+  They can also intimidate disagreeable owners into paying protection, raising fear.
 - **Brain** – sets up illicit businesses behind purchased fronts.
 
 ## Gameplay Loop Example
@@ -22,6 +24,7 @@ This prototype explores a lightweight mafia management loop. Actions unlock prog
 4. Use Face gangsters to expand territory and earn more money.
 5. Have Brains purchase businesses and then create illicit operations behind them. When building an illicit operation you can select from counterfeiting money, producing drugs, running illegal gambling or fencing stolen goods.
 6. Balance money, territory, patrols and heat while gradually growing your empire.
-7. Occasionally an extorted business owner may be disagreeable. They refuse to pay, increase heat and are tracked by a new "disagreeable owners" counter.
+7. Occasionally an extorted business owner may be disagreeable. They refuse to pay, increase heat and are tracked by a "disagreeable owners" counter.
+8. Send Fists to intimidate these owners. Successful intimidation removes one disagreeable owner and increases fear.
 
 These notes are kept short on purpose – the goal is simply to track the prototype design as it evolves.

--- a/index.html
+++ b/index.html
@@ -104,6 +104,7 @@
 <div class="counter">Territory: <span id="territory">0</span> block(s)</div>
 <div class="counter">Heat: <span id="heat">0</span> (<span id="heatProgress">0</span>/10)</div>
 <div class="counter">Disagreeable Owners: <span id="disagreeableOwners">0</span></div>
+<div class="counter">Fear: <span id="fear">0</span></div>
 <div class="counter">Businesses: <span id="businesses">0</span></div>
 <div class="counter">Faces: <span id="faces">0</span></div>
 <div class="counter">Fists: <span id="fists">0</span></div>
@@ -148,6 +149,7 @@ const state = {
     heat: 0,
     heatProgress: 0,
     disagreeableOwners: 0,
+    fear: 0,
     businesses: 0,
     unlockedEnforcer: false,
     unlockedGangster: false,
@@ -180,6 +182,7 @@ function updateUI() {
     document.getElementById('heat').textContent = state.heat;
     document.getElementById('heatProgress').textContent = state.heatProgress;
     document.getElementById('disagreeableOwners').textContent = state.disagreeableOwners;
+    document.getElementById('fear').textContent = state.fear;
     document.getElementById('businesses').textContent = state.businesses;
     const available = state.businesses - state.illicit - state.illicitProgress;
     document.getElementById('availableFronts').textContent = available;
@@ -471,16 +474,25 @@ function renderGangsters() {
             auxProg.className = 'progress hidden';
             auxProg.innerHTML = '<div class="progress-bar"></div>';
 
+            const fearBtn = document.createElement('button');
+            const fearProg = document.createElement('div');
+            fearProg.className = 'progress hidden';
+            fearProg.innerHTML = '<div class="progress-bar"></div>';
+
             row.appendChild(btn);
             row.appendChild(prog);
             row.appendChild(auxBtn);
             row.appendChild(auxProg);
+            row.appendChild(fearBtn);
+            row.appendChild(fearProg);
 
             g.element = row;
             g.button = btn;
             g.progress = prog;
             g.auxButton = auxBtn;
             g.auxProgress = auxProg;
+            g.fearButton = fearBtn;
+            g.fearProgress = fearProg;
 
             if (g.type === 'face') faceDiv.appendChild(row);
             else if (g.type === 'brain') brainDiv.appendChild(row);
@@ -571,12 +583,14 @@ function renderGangsters() {
                     g.busy = true;
                     btn.disabled = true;
                     auxBtn.disabled = true;
+                    fearBtn.disabled = true;
                     runProgress(prog, 2000, () => {
                         state.patrol += 1;
                         state.unlockedGangster = true;
                         g.busy = false;
                         btn.disabled = false;
                         auxBtn.disabled = false;
+                        fearBtn.disabled = false;
                     });
                 };
 
@@ -585,12 +599,31 @@ function renderGangsters() {
                     g.busy = true;
                     btn.disabled = true;
                     auxBtn.disabled = true;
+                    fearBtn.disabled = true;
                     runProgress(auxProg, 5000, () => {
                         state.money += 150;
                         state.heat += 1;
                         g.busy = false;
                         btn.disabled = false;
                         auxBtn.disabled = false;
+                        fearBtn.disabled = false;
+                    });
+                };
+
+                fearBtn.onclick = () => {
+                    if (g.busy) return;
+                    if (state.disagreeableOwners <= 0) return alert('No disagreeable owners');
+                    g.busy = true;
+                    btn.disabled = true;
+                    auxBtn.disabled = true;
+                    fearBtn.disabled = true;
+                    runProgress(fearProg, 3000, () => {
+                        state.disagreeableOwners -= 1;
+                        state.fear += 1;
+                        g.busy = false;
+                        btn.disabled = false;
+                        auxBtn.disabled = false;
+                        fearBtn.disabled = false;
                     });
                 };
             }
@@ -611,6 +644,8 @@ function renderGangsters() {
             g.button.disabled = g.busy || !state.unlockedEnforcer;
             g.auxButton.textContent = `Fist #${g.id} Raid Business`;
             g.auxButton.disabled = g.busy;
+            g.fearButton.textContent = `Fist #${g.id} Intimidate`;
+            g.fearButton.disabled = g.busy || state.disagreeableOwners <= 0;
         }
     });
 }


### PR DESCRIPTION
## Summary
- add a "fear" counter to track how intimidated local businesses are
- enable Fists to intimidate disagreeable owners, reducing the counter and raising fear
- document the new mechanic and ability in README and design notes

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68771844bbf083268eaffffd51e496a3