### PR TITLE
Revise extortion failure and heat scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For a high level overview of the gameplay ideas, see [game-design.md](game-desig
 
 Open `index.html` in any modern web browser. No build step or server is required.
 
-You start with only the ability to extort with the boss. Extortion now claims a block of territory while providing a small cash boost. As you perform actions new options will unlock. Faces can recruit additional gangsters, brains buy new businesses and fists bring in more enforcers or raid rival businesses for fast money at the cost of heat. The boss can perform any of these tasks. Recruited enforcers automatically patrol your territory. Progress bars show how long each action takes.
+You start with only the ability to extort with the boss. A successful extortion claims a block of territory without granting immediate cash. Sometimes the attempt fails, leaving you with a disagreeable owner instead of new turf. As you perform actions new options will unlock. Faces can recruit additional gangsters, brains buy new businesses and fists bring in more enforcers or raid rival businesses for fast money at the cost of heat. The boss can perform any of these tasks. Recruited enforcers automatically patrol your territory. Progress bars show how long each action takes. Disagreeable owners steadily push heat up until you address them.
 When establishing an illicit business you are prompted to choose between money counterfeiting, drug production, illegal gambling or fencing operations.
 
 This prototype intentionally uses a very minimal user interface to focus purely on testing the core gameplay loop.

--- a/game-design.md
+++ b/game-design.md
@@ -9,9 +9,9 @@ This prototype explores a lightweight mafia management loop. Actions unlock prog
 - **Heat** – unwanted attention from law enforcement. Can be reduced by paying off cops.
 - **Businesses** – legitimate fronts that can host illicit operations.
 - **Available Fronts** – businesses not yet hosting illicit operations.
-
+-
 ## Gangsters
-- **Face** – used to extort surrounding blocks, expanding territory and generating cash.
+- **Face** – used to extort surrounding blocks, potentially expanding territory if the owner cooperates.
 - **Fist** – recruits enforcers and can raid rival businesses for quick cash at the cost of heat.
 - **Brain** – sets up illicit businesses behind purchased fronts.
 
@@ -19,9 +19,9 @@ This prototype explores a lightweight mafia management loop. Actions unlock prog
 1. Extort with the boss to seize your first block of territory.
 2. Recruit enforcers (they automatically patrol your territory) to keep heat down. Fists specialize in this and can also raid rival businesses for large cash payouts.
 3. Hire gangsters and choose their specialty. Faces handle the recruiting once unlocked.
-4. Use Face gangsters to expand territory and earn more money.
+4. Use Face gangsters to expand territory which increases your passive income.
 5. Have Brains purchase businesses and then create illicit operations behind them. When building an illicit operation you can select from counterfeiting money, producing drugs, running illegal gambling or fencing stolen goods.
-6. Balance money, territory, patrols and heat while gradually growing your empire.
-7. Occasionally an extorted business owner may be disagreeable. They refuse to pay, increase heat and are tracked by a new "disagreeable owners" counter.
+6. Balance money, territory, patrols and heat while gradually growing your empire. Heat rises each second based on unpatrolled blocks and any disagreeable owners.
+7. Occasionally an extortion attempt fails, leaving a disagreeable owner who refuses to pay. Failed extortions do not add territory and the owner will steadily raise heat until dealt with. These are tracked by a "disagreeable owners" counter.
 
 These notes are kept short on purpose – the goal is simply to track the prototype design as it evolves.

--- a/index.html
+++ b/index.html
@@ -324,11 +324,9 @@ function renderBoss() {
             runProgress(extortProg, 3000, () => {
                 if (Math.random() < DISAGREEABLE_CHANCE) {
                     state.disagreeableOwners += 1;
-                    state.heat += 1;
                 } else {
-                    state.money += 15 * state.territory;
+                    state.territory += 1;
                 }
-                state.territory += 1;
                 state.unlockedBusiness = true;
                 state.unlockedEnforcer = true;
                 boss.busy = false;
@@ -495,11 +493,9 @@ function renderGangsters() {
                     runProgress(prog, 4000, () => {
                         if (Math.random() < DISAGREEABLE_CHANCE) {
                             state.disagreeableOwners += 1;
-                            state.heat += 1;
                         } else {
-                            state.money += 15 * state.territory;
+                            state.territory += 1;
                         }
-                        state.territory += 1;
                         state.unlockedBusiness = true;
                         g.busy = false;
                         btn.disabled = false;
@@ -635,12 +631,15 @@ setInterval(() => {
     // income from legitimate and illicit businesses
     state.money += state.businesses * 2;
     state.money += state.illicit * 5;
-    // heat accrues if territory is not fully patrolled
-    if (state.patrol < state.territory) {
-        state.heatProgress += 1;
-        if (state.heatProgress >= 10) {
+    // heat accrues from unpatrolled territory and disagreeable owners
+    let heatTick = state.disagreeableOwners;
+    const unpatrolled = state.territory - state.patrol;
+    if (unpatrolled > 0) heatTick += unpatrolled;
+    if (heatTick > 0) {
+        state.heatProgress += heatTick;
+        while (state.heatProgress >= 10) {
             state.heat += 1;
-            state.heatProgress = 0;
+            state.heatProgress -= 10;
         }
     } else {
         state.heatProgress = 0;


### PR DESCRIPTION
## Summary
- extortion only expands territory if successful
- disagreeable owners no longer cause instant heat
- heat per tick scales with unpatrolled blocks
- update docs on failed extortion and ongoing heat

## Testing
- `tidy -e index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687717a4a0008326b368f9b29511786b