### PR TITLE
Remove stray closing tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,6 @@
 
     <button id="payCops" class="hidden">Pay Off Cops ($50)</button>
     <div id="payCopsProgress" class="progress hidden"><div class="progress-bar"></div></div>
-</div>
 
 <script>
 const state = {


### PR DESCRIPTION
## Summary
- fix extra `</div>` in the Pay Cops section

## Testing
- `python3 - <<'PY'
from html.parser import HTMLParser
class MyParser(HTMLParser):
    def __init__(self):
        super().__init__()
        self.stack=[]
        self.errors=[]
    def handle_starttag(self, tag, attrs):
        if tag in ['area','base','br','col','command','embed','hr','img','input','keygen','link','meta','param','source','track','wbr']:
            return
        self.stack.append(tag)
    def handle_endtag(self, tag):
        if tag in self.stack[::-1]:
            while self.stack:
                top=self.stack.pop()
                if top==tag:
                    break
        else:
            self.errors.append('Unexpected </'+tag+'>')

p=MyParser()
html=open('index.html').read()
p.feed(html)
print('remaining stack:',p.stack)
print('errors:',p.errors)
PY

------
https://chatgpt.com/codex/tasks/task_e_68772f7b78b48326bb673d96478f237d