### PR TITLE
Add money laundering action

### DIFF
--- a/game-design.md
+++ b/game-design.md
@@ -16,6 +16,7 @@ This prototype explores a lightweight mafia management loop. Actions unlock prog
 - **Fist** – recruits enforcers and can raid rival businesses for quick cash at the cost of heat.
   They can also intimidate disagreeable owners into paying protection, raising fear.
 - **Brain** – sets up illicit businesses behind purchased fronts.
+  They can also launder dirty money into clean profits once businesses are available.
 
 ## Gameplay Loop Example
 1. Extort with the boss to seize your first block of territory.

--- a/game.js
+++ b/game.js
@@ -506,6 +506,24 @@ class Game {
               btn.disabled = false;
             });
           };
+
+          fearBtn.onclick = () => {
+            if (g.busy) return;
+            if (!(state.unlockedBusiness || state.unlockedIllicit)) return;
+            if (state.dirtyMoney < 100) return alert('Not enough dirty money');
+            g.busy = true;
+            btn.disabled = true;
+            auxBtn.disabled = true;
+            fearBtn.disabled = true;
+            state.dirtyMoney -= 100;
+            this.runProgress(fearProg, 5000, () => {
+              state.cleanMoney += 80;
+              g.busy = false;
+              btn.disabled = false;
+              auxBtn.disabled = false;
+              fearBtn.disabled = false;
+            });
+          };
         } else if (g.type === 'fist') {
           btn.onclick = () => {
             if (g.busy) return;
@@ -570,6 +588,11 @@ class Game {
         g.button.disabled = g.busy || !state.unlockedIllicit || avail <= 0;
         g.auxButton.textContent = `Brain #${g.id} Buy Business`;
         g.auxButton.disabled = g.busy || !state.unlockedBusiness;
+        const showLaunder = state.unlockedBusiness || state.unlockedIllicit;
+        g.fearButton.textContent = `Brain #${g.id} Launder Money`;
+        g.fearButton.classList.toggle('hidden', !showLaunder);
+        if (!showLaunder) g.fearProgress.classList.add('hidden');
+        g.fearButton.disabled = g.busy || state.dirtyMoney < 100;
       } else if (g.type === 'fist') {
         g.button.textContent = `Fist #${g.id} Recruit Enforcer`;
         g.button.disabled = g.busy || !state.unlockedEnforcer;


### PR DESCRIPTION
## Summary
- enable brains to launder money with dirty→clean conversion
- document that brains can launder funds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687afbb7ab0083269ae0f4d18c54d585