### PR TITLE
Fix recruiting popup queue

### DIFF
--- a/game.js
+++ b/game.js
@@ -25,6 +25,7 @@ class Game {
       nextGangId: 1,
     };
     this.DISAGREEABLE_CHANCE = 0.2;
+    this.recruitQueue = [];
 
     this.darkToggle = document.getElementById('darkToggle');
     const storedDark = localStorage.getItem('dark') === '1';
@@ -154,6 +155,13 @@ class Game {
   }
 
   showGangsterTypeSelection(callback) {
+    this.recruitQueue.push(callback);
+    if (this.recruitQueue.length === 1) {
+      this.displayNextGangsterSelection();
+    }
+  }
+
+  displayNextGangsterSelection() {
     const container = document.getElementById('gangsterChoice');
     container.classList.remove('hidden');
 
@@ -162,8 +170,12 @@ class Game {
       document.getElementById('chooseFace').onclick = null;
       document.getElementById('chooseFist').onclick = null;
       document.getElementById('chooseBrain').onclick = null;
-      callback(type);
+      const cb = this.recruitQueue.shift();
+      cb(type);
       this.updateUI();
+      if (this.recruitQueue.length > 0) {
+        this.displayNextGangsterSelection();
+      }
     };
 
     document.getElementById('chooseFace').onclick = () => choose('face');


### PR DESCRIPTION
## Summary
- add `recruitQueue` to queue pending gangster type selections
- display each recruiter popup sequentially with new `displayNextGangsterSelection` method

## Testing
- `node -c game.js` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687afe6018588326bffda957b1ba63fd