### PR TITLE
Add respect resource and new actions

### DIFF
--- a/game-design.md
+++ b/game-design.md
@@ -10,11 +10,12 @@ This prototype explores a lightweight mafia management loop. Actions unlock prog
 - **Businesses** – legitimate fronts that can host illicit operations.
 - **Available Fronts** – businesses not yet hosting illicit operations.
 - **Fear** – represents how cowed local businesses are. Certain actions raise it and may unlock future bonuses.
+- **Respect** – goodwill earned by helping the community. Provides small passive income boosts.
 
 ## Gangsters
-- **Face** – used to extort surrounding blocks, potentially expanding territory if the owner cooperates.
+- **Face** – used to extort surrounding blocks, potentially expanding territory if the owner cooperates. Faces can spend clean money on PR to earn respect.
 - **Fist** – recruits enforcers and can raid rival businesses for quick cash at the cost of heat.
-  They can also intimidate disagreeable owners into paying protection, raising fear.
+  They can also intimidate disagreeable owners into paying protection, raising fear, or simply show force anywhere to boost fear while generating heat.
 - **Brain** – sets up illicit businesses behind purchased fronts.
   They can also launder dirty money into clean profits once businesses are available.
 

--- a/index.html
+++ b/index.html
@@ -112,6 +112,8 @@
 <div class="counter">Disagreeable Owners: <span id="disagreeableOwners">0</span></div>
 <div class="counter">Fear: <span id="fear">0</span></div>
 <div class="counter">Fear Bonus: <span id="fearBonus">None</span></div>
+<div class="counter">Respect: <span id="respect">0</span></div>
+<div class="counter">Respect Bonus: <span id="respectBonus">None</span></div>
 <div class="counter">Businesses: <span id="businesses">0</span></div>
 <div class="counter">Faces: <span id="faces">0</span></div>
 <div class="counter">Fists: <span id="fists">0</span></div>


### PR DESCRIPTION
## Summary
- introduce `respect` stat with UI and persistence
- grant clean money bonus from respect levels
- allow faces to run PR campaigns for respect
- add boss charity action
- add fist 'show force' action for fear regardless of disagreeable owners
- document respect in design notes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b38881e708326a2b6b1f220ade701