### PR TITLE
Add respect stat with outreach actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ For a high level overview of the gameplay ideas, see [game-design.md](game-desig
 Open `index.html` in any modern web browser. No build step or server is required.
 
 You start with only the ability to extort with the boss. A successful extortion claims a block of territory without granting immediate cash. Sometimes the attempt fails, leaving you with a disagreeable owner instead of new turf. As you perform actions new options will unlock. Faces can recruit additional gangsters, brains buy new businesses and fists bring in more enforcers or raid rival businesses for fast money at the cost of heat. Fists can also intimidate disagreeable owners into paying protection, raising a new **fear** meter. The boss can perform any of these tasks. Recruited enforcers automatically patrol your territory. Progress bars show how long each action takes. Disagreeable owners steadily push heat up until you address them.
+Faces and the boss can also perform community outreach to earn **respect**, slowing future heat growth.
 When establishing an illicit business you are prompted to choose between money counterfeiting, drug production, illegal gambling or fencing operations.
 
 This prototype intentionally uses a very minimal user interface to focus purely on testing the core gameplay loop.

--- a/game-design.md
+++ b/game-design.md
@@ -10,11 +10,14 @@ This prototype explores a lightweight mafia management loop. Actions unlock prog
 - **Businesses** – legitimate fronts that can host illicit operations.
 - **Available Fronts** – businesses not yet hosting illicit operations.
 - **Fear** – represents how cowed local businesses are. Certain actions raise it and may unlock future bonuses.
+- **Respect** – earned through community outreach. Each 5 points lowers heat gain by 1.
 
 ## Gangsters
 - **Face** – used to extort surrounding blocks, potentially expanding territory if the owner cooperates.
 - **Fist** – recruits enforcers and can raid rival businesses for quick cash at the cost of heat.
   They can also intimidate disagreeable owners into paying protection, raising fear.
+- **Boss** – can donate to charities to build respect.
+- **Face** – can schmooze with locals to gain respect.
 - **Brain** – sets up illicit businesses behind purchased fronts.
   They can also launder dirty money into clean profits once businesses are available.
 
@@ -27,5 +30,6 @@ This prototype explores a lightweight mafia management loop. Actions unlock prog
 6. Balance money, territory, patrols and heat while gradually growing your empire. Heat rises each second based on unpatrolled blocks and any disagreeable owners.
 7. Occasionally an extortion attempt fails, leaving a disagreeable owner who refuses to pay. Failed extortions do not add territory and the owner will steadily raise heat until dealt with. These are tracked by a "disagreeable owners" counter.
 8. Send Fists to intimidate these owners. Successful intimidation removes one disagreeable owner and increases fear.
+9. Use Faces or the Boss to perform community outreach and build respect, slowing future heat growth.
 
 These notes are kept short on purpose – the goal is simply to track the prototype design as it evolves.

--- a/index.html
+++ b/index.html
@@ -112,6 +112,8 @@
 <div class="counter">Disagreeable Owners: <span id="disagreeableOwners">0</span></div>
 <div class="counter">Fear: <span id="fear">0</span></div>
 <div class="counter">Fear Bonus: <span id="fearBonus">None</span></div>
+<div class="counter">Respect: <span id="respect">0</span></div>
+<div class="counter">Respect Bonus: <span id="respectBonus">None</span></div>
 <div class="counter">Businesses: <span id="businesses">0</span></div>
 <div class="counter">Faces: <span id="faces">0</span></div>
 <div class="counter">Fists: <span id="fists">0</span></div>


### PR DESCRIPTION
## Summary
- track a new respect resource alongside fear
- add community outreach actions for the boss and faces
- allow fists to intimidate even when no disagreeable owners remain
- display respect counters and bonuses
- factor respect into heat generation
- update design notes and README

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_687b38881e708326a2b6b1f220ade701