### PR TITLE
Enable universal gangster actions

### DIFF
--- a/game-design.md
+++ b/game-design.md
@@ -16,7 +16,7 @@ This prototype explores a lightweight mafia management loop. Actions unlock prog
 - **Fist** – recruits enforcers and can raid rival businesses for quick cash at the cost of heat.
   They can also intimidate disagreeable owners into paying protection, raising fear.
 - **Brain** – sets up illicit businesses behind purchased fronts.
-  They can also launder dirty money into clean profits once businesses are available.
+ They can also launder dirty money into clean profits once businesses are available.
 
 ## Gameplay Loop Example
 1. Extort with the boss to seize your first block of territory.
@@ -27,5 +27,15 @@ This prototype explores a lightweight mafia management loop. Actions unlock prog
 6. Balance money, territory, patrols and heat while gradually growing your empire. Heat rises each second based on unpatrolled blocks and any disagreeable owners.
 7. Occasionally an extortion attempt fails, leaving a disagreeable owner who refuses to pay. Failed extortions do not add territory and the owner will steadily raise heat until dealt with. These are tracked by a "disagreeable owners" counter.
 8. Send Fists to intimidate these owners. Successful intimidation removes one disagreeable owner and increases fear.
+
+
+## Gangster Role Refactor
+Each gangster now has a specialty (Face, Fist or Brain) but can perform any unlocked action. Their specialty simply grants a speed bonus:
+
+- **Faces** excel at extorting territory and recruiting new gangsters.
+- **Fists** excel at recruiting enforcers, raiding businesses and intimidating owners.
+- **Brains** excel at purchasing businesses, building illicit operations and laundering money.
+
+The UI provides a single action selector for every gangster so the player may assign any task. Progress times are reduced by 25% when a gangster performs an action matching their specialty.
 
 These notes are kept short on purpose – the goal is simply to track the prototype design as it evolves.

--- a/game.js
+++ b/game.js
@@ -25,6 +25,26 @@ class Game {
       nextGangId: 1,
     };
     this.DISAGREEABLE_CHANCE = 0.2;
+    this.ACTION_LABELS = {
+      extort: 'Extort',
+      recruitGangster: 'Recruit Gangster',
+      buildIllicit: 'Build Illicit',
+      buyBusiness: 'Buy Business',
+      launder: 'Launder Money',
+      recruitEnforcer: 'Recruit Enforcer',
+      raid: 'Raid Business',
+      intimidate: 'Intimidate',
+    };
+    this.ACTION_DURATIONS = {
+      extort: 4000,
+      recruitGangster: 3000,
+      buildIllicit: 4000,
+      buyBusiness: 5000,
+      launder: 5000,
+      recruitEnforcer: 2000,
+      raid: 5000,
+      intimidate: 3000,
+    };
 
     this.darkToggle = document.getElementById('darkToggle');
     const storedDark = localStorage.getItem('dark') === '1';
@@ -219,6 +239,145 @@ class Game {
     document.getElementById('chooseDrugs').onclick = () => choose('drugs');
     document.getElementById('chooseGambling').onclick = () => choose('gambling');
     document.getElementById('chooseFencing').onclick = () => choose('fencing');
+  }
+
+  availableActions() {
+    const s = this.state;
+    const availFronts = s.businesses - s.illicit - s.illicitProgress;
+    const actions = ['extort'];
+    if (s.unlockedGangster) actions.push('recruitGangster');
+    if (s.unlockedIllicit && availFronts > 0) actions.push('buildIllicit');
+    if (s.unlockedBusiness) actions.push('buyBusiness');
+    if (s.unlockedBusiness || s.unlockedIllicit) actions.push('launder');
+    if (s.unlockedEnforcer) actions.push('recruitEnforcer');
+    actions.push('raid');
+    if (s.disagreeableOwners > 0) actions.push('intimidate');
+    return actions;
+  }
+
+  skillMultiplier(g, action) {
+    if (g.type === 'face' && (action === 'extort' || action === 'recruitGangster')) return 0.75;
+    if (g.type === 'brain' && (action === 'buildIllicit' || action === 'buyBusiness' || action === 'launder')) return 0.75;
+    if (g.type === 'fist' && (action === 'recruitEnforcer' || action === 'raid' || action === 'intimidate')) return 0.75;
+    return 1;
+  }
+
+  startGangsterAction(g, action) {
+    const s = this.state;
+    let duration = this.ACTION_DURATIONS[action] * this.skillMultiplier(g, action);
+    if (action === 'extort') duration = this.extortDuration(duration);
+    const finish = () => {
+      g.busy = false;
+      g.button.disabled = false;
+      g.select.disabled = false;
+    };
+    switch (action) {
+      case 'extort':
+        g.busy = true;
+        g.button.disabled = true;
+        g.select.disabled = true;
+        this.runProgress(g.progress, duration, () => {
+          if (Math.random() < this.DISAGREEABLE_CHANCE) s.disagreeableOwners += 1; else s.territory += 1;
+          s.unlockedBusiness = true;
+          s.unlockedEnforcer = true;
+          finish();
+        });
+        break;
+      case 'recruitGangster':
+        if (!s.unlockedGangster) return alert('Recruit enforcers first');
+        const gCost = this.gangsterCost();
+        if (this.totalMoney() < gCost) return alert('Not enough money');
+        this.spendMoney(gCost);
+        g.busy = true;
+        g.button.disabled = true;
+        g.select.disabled = true;
+        this.runProgress(g.progress, duration, () => {
+          this.showGangsterTypeSelection(choice => {
+            const n = { id: s.nextGangId++, type: choice, busy: false };
+            s.gangsters.push(n);
+            finish();
+            this.updateUI();
+          });
+        });
+        break;
+      case 'buildIllicit':
+        if (s.businesses - s.illicit - s.illicitProgress <= 0) return alert('No available fronts');
+        g.busy = true;
+        g.button.disabled = true;
+        g.select.disabled = true;
+        s.illicitProgress += 1;
+        this.updateUI();
+        this.runProgress(g.progress, duration, () => {
+          s.illicitProgress -= 1;
+          this.showIllicitBusinessSelection(choice => {
+            s.illicitCounts[choice] += 1;
+            s.illicit += 1;
+            finish();
+            this.updateUI();
+          });
+        });
+        break;
+      case 'buyBusiness':
+        if (!s.unlockedBusiness) return alert('No territory yet');
+        if (this.totalMoney() < 100) return alert('Not enough money');
+        this.spendMoney(100);
+        g.busy = true;
+        g.button.disabled = true;
+        g.select.disabled = true;
+        this.runProgress(g.progress, duration, () => {
+          s.businesses += 1;
+          s.unlockedIllicit = true;
+          finish();
+        });
+        break;
+      case 'launder':
+        if (!(s.unlockedBusiness || s.unlockedIllicit)) return;
+        if (s.dirtyMoney < 100) return alert('Not enough dirty money');
+        s.dirtyMoney -= 100;
+        g.busy = true;
+        g.button.disabled = true;
+        g.select.disabled = true;
+        this.runProgress(g.progress, duration, () => {
+          s.cleanMoney += 80;
+          finish();
+        });
+        break;
+      case 'recruitEnforcer':
+        if (!s.unlockedEnforcer) return alert('Not unlocked');
+        const cost = this.enforcerCost();
+        if (this.totalMoney() < cost) return alert('Not enough money');
+        this.spendMoney(cost);
+        g.busy = true;
+        g.button.disabled = true;
+        g.select.disabled = true;
+        this.runProgress(g.progress, duration, () => {
+          s.patrol += 1;
+          s.unlockedGangster = true;
+          finish();
+        });
+        break;
+      case 'raid':
+        g.busy = true;
+        g.button.disabled = true;
+        g.select.disabled = true;
+        this.runProgress(g.progress, duration, () => {
+          s.dirtyMoney += 150;
+          s.heat += 1;
+          finish();
+        });
+        break;
+      case 'intimidate':
+        if (s.disagreeableOwners <= 0) return alert('No disagreeable owners');
+        g.busy = true;
+        g.button.disabled = true;
+        g.select.disabled = true;
+        this.runProgress(g.progress, duration, () => {
+          s.disagreeableOwners -= 1;
+          s.fear += 1;
+          finish();
+        });
+        break;
+    }
   }
 
   renderBoss() {
@@ -420,226 +579,54 @@ class Game {
 
   renderGangsters() {
     const state = this.state;
-    const faceDiv = document.getElementById('facesContainer');
-    const brainDiv = document.getElementById('brainsContainer');
-    const fistDiv = document.getElementById('fistsContainer');
+    const container = document.getElementById('gangstersContainer');
     state.gangsters.forEach(g => {
       if (!g.element) {
         const row = document.createElement('div');
         row.className = 'action';
 
+        const label = document.createElement('span');
+        label.style.marginRight = '4px';
+
+        const select = document.createElement('select');
         const btn = document.createElement('button');
         const prog = document.createElement('div');
         prog.className = 'progress hidden';
         prog.innerHTML = '<div class="progress-bar"></div>';
 
-        const auxBtn = document.createElement('button');
-        const auxProg = document.createElement('div');
-        auxProg.className = 'progress hidden';
-        auxProg.innerHTML = '<div class="progress-bar"></div>';
-
-        let fearBtn, fearProg;
-
+        row.appendChild(label);
+        row.appendChild(select);
         row.appendChild(btn);
         row.appendChild(prog);
-        row.appendChild(auxBtn);
-        row.appendChild(auxProg);
-        if (g.type === 'fist') {
-          fearBtn = document.createElement('button');
-          fearProg = document.createElement('div');
-          fearProg.className = 'progress hidden';
-          fearProg.innerHTML = '<div class="progress-bar"></div>';
-          row.appendChild(fearBtn);
-          row.appendChild(fearProg);
-        }
 
         g.element = row;
+        g.label = label;
+        g.select = select;
         g.button = btn;
         g.progress = prog;
-        g.auxButton = auxBtn;
-        g.auxProgress = auxProg;
-        if (g.type === 'fist') {
-          g.fearButton = fearBtn;
-          g.fearProgress = fearProg;
-        }
 
-        if (g.type === 'face') faceDiv.appendChild(row);
-        else if (g.type === 'brain') brainDiv.appendChild(row);
-        else if (g.type === 'fist') fistDiv.appendChild(row);
+        btn.onclick = () => {
+          if (g.busy) return;
+          this.startGangsterAction(g, select.value);
+        };
 
-        if (g.type === 'face') {
-          btn.onclick = () => {
-            if (g.busy) return;
-            g.busy = true;
-            btn.disabled = true;
-            auxBtn.disabled = true;
-            this.runProgress(prog, this.extortDuration(4000), () => {
-              if (Math.random() < this.DISAGREEABLE_CHANCE) {
-                state.disagreeableOwners += 1;
-              } else {
-                state.territory += 1;
-              }
-              state.unlockedBusiness = true;
-              g.busy = false;
-              btn.disabled = false;
-              auxBtn.disabled = false;
-            });
-          };
-
-          auxBtn.onclick = () => {
-            if (g.busy) return;
-            if (!state.unlockedGangster) return alert('Recruit enforcers first');
-            const gCost = this.gangsterCost();
-            if (this.totalMoney() < gCost) return alert('Not enough money');
-            g.busy = true;
-            auxBtn.disabled = true;
-            btn.disabled = true;
-            this.spendMoney(gCost);
-            this.runProgress(auxProg, 3000, () => {
-              this.showGangsterTypeSelection(choice => {
-                const n = { id: state.nextGangId++, type: choice, busy: false };
-                state.gangsters.push(n);
-                g.busy = false;
-                auxBtn.disabled = false;
-                btn.disabled = false;
-                this.updateUI();
-              });
-            });
-          };
-        } else if (g.type === 'brain') {
-          btn.onclick = () => {
-            if (g.busy) return;
-            if (state.businesses - state.illicit - state.illicitProgress <= 0) return alert('No available fronts');
-            g.busy = true;
-            btn.disabled = true;
-            auxBtn.disabled = true;
-            state.illicitProgress += 1;
-            this.updateUI();
-            this.runProgress(prog, 4000, () => {
-              state.illicitProgress -= 1;
-              this.showIllicitBusinessSelection(choice => {
-                state.illicitCounts[choice] += 1;
-                state.illicit += 1;
-                g.busy = false;
-                btn.disabled = false;
-                auxBtn.disabled = false;
-                this.updateUI();
-              });
-            });
-          };
-
-          auxBtn.onclick = () => {
-            if (g.busy) return;
-            if (!state.unlockedBusiness) return alert('No territory yet');
-            if (this.totalMoney() < 100) return alert('Not enough money');
-            g.busy = true;
-            auxBtn.disabled = true;
-            btn.disabled = true;
-            this.spendMoney(100);
-            this.runProgress(auxProg, 5000, () => {
-              state.businesses += 1;
-              state.unlockedIllicit = true;
-              g.busy = false;
-              auxBtn.disabled = false;
-              btn.disabled = false;
-            });
-          };
-
-          fearBtn.onclick = () => {
-            if (g.busy) return;
-            if (!(state.unlockedBusiness || state.unlockedIllicit)) return;
-            if (state.dirtyMoney < 100) return alert('Not enough dirty money');
-            g.busy = true;
-            btn.disabled = true;
-            auxBtn.disabled = true;
-            fearBtn.disabled = true;
-            state.dirtyMoney -= 100;
-            this.runProgress(fearProg, 5000, () => {
-              state.cleanMoney += 80;
-              g.busy = false;
-              btn.disabled = false;
-              auxBtn.disabled = false;
-              fearBtn.disabled = false;
-            });
-          };
-        } else if (g.type === 'fist') {
-          btn.onclick = () => {
-            if (g.busy) return;
-            const cost = this.enforcerCost();
-            if (this.totalMoney() < cost) return alert('Not enough money');
-            g.busy = true;
-            btn.disabled = true;
-            auxBtn.disabled = true;
-            fearBtn.disabled = true;
-            this.spendMoney(cost);
-            this.runProgress(prog, 2000, () => {
-              state.patrol += 1;
-              state.unlockedGangster = true;
-              g.busy = false;
-              btn.disabled = false;
-              auxBtn.disabled = false;
-              fearBtn.disabled = false;
-            });
-          };
-
-          auxBtn.onclick = () => {
-            if (g.busy) return;
-            g.busy = true;
-            btn.disabled = true;
-            auxBtn.disabled = true;
-            fearBtn.disabled = true;
-            this.runProgress(auxProg, 5000, () => {
-              state.dirtyMoney += 150;
-              state.heat += 1;
-              g.busy = false;
-              btn.disabled = false;
-              auxBtn.disabled = false;
-              fearBtn.disabled = false;
-            });
-          };
-
-          fearBtn.onclick = () => {
-            if (g.busy) return;
-            if (state.disagreeableOwners <= 0) return alert('No disagreeable owners');
-            g.busy = true;
-            btn.disabled = true;
-            auxBtn.disabled = true;
-            fearBtn.disabled = true;
-            this.runProgress(fearProg, 3000, () => {
-              state.disagreeableOwners -= 1;
-              state.fear += 1;
-              g.busy = false;
-              btn.disabled = false;
-              auxBtn.disabled = false;
-              fearBtn.disabled = false;
-            });
-          };
-        }
+        container.appendChild(row);
       }
-      if (g.type === 'face') {
-        g.button.textContent = `Face #${g.id} Extort`;
-        g.button.disabled = g.busy;
-        g.auxButton.textContent = `Face #${g.id} Recruit Gangster`;
-        g.auxButton.disabled = g.busy || !state.unlockedGangster;
-      } else if (g.type === 'brain') {
-        g.button.textContent = `Brain #${g.id} Build Illicit`;
-        const avail = state.businesses - state.illicit - state.illicitProgress;
-        g.button.disabled = g.busy || !state.unlockedIllicit || avail <= 0;
-        g.auxButton.textContent = `Brain #${g.id} Buy Business`;
-        g.auxButton.disabled = g.busy || !state.unlockedBusiness;
-        const showLaunder = state.unlockedBusiness || state.unlockedIllicit;
-        g.fearButton.textContent = `Brain #${g.id} Launder Money`;
-        g.fearButton.classList.toggle('hidden', !showLaunder);
-        if (!showLaunder) g.fearProgress.classList.add('hidden');
-        g.fearButton.disabled = g.busy || state.dirtyMoney < 100;
-      } else if (g.type === 'fist') {
-        g.button.textContent = `Fist #${g.id} Recruit Enforcer`;
-        g.button.disabled = g.busy || !state.unlockedEnforcer;
-        g.auxButton.textContent = `Fist #${g.id} Raid Business`;
-        g.auxButton.disabled = g.busy;
-        g.fearButton.textContent = `Fist #${g.id} Intimidate`;
-        g.fearButton.disabled = g.busy || state.disagreeableOwners <= 0;
-      }
+
+      g.label.textContent = `${g.type.charAt(0).toUpperCase() + g.type.slice(1)} #${g.id}`;
+      g.select.disabled = g.busy;
+      g.button.disabled = g.busy;
+
+      const options = this.availableActions();
+      g.select.innerHTML = '';
+      options.forEach(act => {
+        const opt = document.createElement('option');
+        opt.value = act;
+        opt.textContent = this.ACTION_LABELS[act];
+        g.select.appendChild(opt);
+      });
+
+      g.button.textContent = this.ACTION_LABELS[g.select.value];
     });
   }
 

--- a/index.html
+++ b/index.html
@@ -87,6 +87,9 @@
     .action button {
       margin: 0;
     }
+    .action select {
+      margin-right: 4px;
+    }
     .action .progress {
       position: absolute;
       right: 0;
@@ -124,9 +127,7 @@
 <div class="counter">Available Fronts: <span id="availableFronts">0</span></div>
 <hr>
 <div id="bossContainer"></div>
-<div id="facesContainer"></div>
-<div id="fistsContainer"></div>
-<div id="brainsContainer"></div>
+<div id="gangstersContainer"></div>
 
 <div id="gangsterChoice" class="hidden">
     <p>Select gangster type:</p>


### PR DESCRIPTION
## Summary
- allow all gangsters to perform any unlocked action but apply a speed bonus based on their specialty
- drop individual gangster containers and add a unified `gangstersContainer`
- supply a dropdown to choose each gangster's action
- document the new role system

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_687b38dc90dc83268237ff838722efdf