### PR TITLE
Add personal heat and risk mechanics

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,7 @@
 <div class="counter">Gambling Dens: <span id="gamblingCount">0</span></div>
 <div class="counter">Fencing Rings: <span id="fencingCount">0</span></div>
 <div class="counter">Available Fronts: <span id="availableFronts">0</span></div>
+<div class="counter">Boss Heat: <span id="bossHeat">0</span> (Min <span id="bossMinHeat">0</span>)</div>
 <hr>
 <div id="bossContainer"></div>
 <div id="facesContainer"></div>


### PR DESCRIPTION
## Summary
- introduce personal heat with permanent minimum heat value
- implement operation risk that scales with personal heat
- add boss heat display in UI and heat display for each gangster
- heat decays over time but not below minimal heat

## Testing
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_e_687b3991bb2c832684430f79f94f5526