### PR TITLE
Queue gangster type selection popups

### DIFF
--- a/game.js
+++ b/game.js
@@ -25,6 +25,7 @@ class Game {
       nextGangId: 1,
     };
     this.DISAGREEABLE_CHANCE = 0.2;
+    this.recruitQueue = [];
 
     this.darkToggle = document.getElementById('darkToggle');
     const storedDark = localStorage.getItem('dark') === '1';
@@ -184,6 +185,14 @@ class Game {
   }
 
   showGangsterTypeSelection(callback) {
+    this.recruitQueue.push(callback);
+    if (this.recruitQueue.length === 1) {
+      this.displayGangsterTypeSelection();
+    }
+  }
+
+  displayGangsterTypeSelection() {
+    if (this.recruitQueue.length === 0) return;
     const container = document.getElementById('gangsterChoice');
     container.classList.remove('hidden');
 
@@ -192,8 +201,12 @@ class Game {
       document.getElementById('chooseFace').onclick = null;
       document.getElementById('chooseFist').onclick = null;
       document.getElementById('chooseBrain').onclick = null;
-      callback(type);
+      const cb = this.recruitQueue.shift();
+      cb(type);
       this.updateUI();
+      if (this.recruitQueue.length > 0) {
+        this.displayGangsterTypeSelection();
+      }
     };
 
     document.getElementById('chooseFace').onclick = () => choose('face');
@@ -679,4 +692,8 @@ class Game {
 window.addEventListener('DOMContentLoaded', () => {
   new Game();
 });
+
+if (typeof module !== 'undefined') {
+  module.exports = Game;
+}
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "gangster-game",
+  "version": "1.0.0",
+  "description": "This repository contains a very small prototype for a mafia management game. The game is a semi-idle experiment inspired by games like **Cultist Simulator**. Gameplay revolves around balancing money, manpower and heat while expanding your criminal empire.",
+  "main": "game.js",
+  "scripts": {
+    "test": "node test/recruitQueue.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/test/recruitQueue.test.js
+++ b/test/recruitQueue.test.js
@@ -1,0 +1,92 @@
+const assert = require('assert');
+
+function createElement(hidden=true) {
+  return {
+    classList: {
+      classes: new Set(hidden ? ['hidden'] : []),
+      add(cls){this.classes.add(cls);},
+      remove(cls){this.classes.delete(cls);},
+      contains(cls){return this.classes.has(cls);}
+    },
+    onclick: null
+  };
+}
+
+const elements = {
+  gangsterChoice: createElement(),
+  chooseFace: createElement(false),
+  chooseFist: createElement(false),
+  chooseBrain: createElement(false)
+};
+
+global.document = {
+  getElementById(id) {
+    if (!elements[id]) elements[id] = createElement(false);
+    return elements[id];
+  }
+};
+
+global.alert = () => {};
+global.window = { addEventListener: () => {} };
+
+const Game = require('../game.js');
+const game = Object.create(Game.prototype);
+game.recruitQueue = [];
+game.updateUI = () => {};
+
+describe('recruit queue', () => {
+  it('processes multiple recruiters sequentially', () => {
+    const g1 = {busy: true};
+    const g2 = {busy: true};
+    game.showGangsterTypeSelection(type => { g1.busy = false; });
+    game.showGangsterTypeSelection(type => { g2.busy = false; });
+    const container = elements.gangsterChoice;
+    assert(!container.classList.contains('hidden'));
+    elements.chooseFace.onclick();
+    assert.strictEqual(g1.busy, false);
+    assert.strictEqual(g2.busy, true);
+    assert(!container.classList.contains('hidden'));
+    elements.chooseBrain.onclick();
+    assert.strictEqual(g2.busy, false);
+    assert(container.classList.contains('hidden'));
+  });
+
+  it('handles recruiters added while popup open', () => {
+    game.recruitQueue = [];
+    elements.gangsterChoice.classList.add('hidden');
+    const container = elements.gangsterChoice;
+    const g1 = {busy: true};
+    const g2 = {busy: true};
+    const g3 = {busy: true};
+    game.showGangsterTypeSelection(() => { g1.busy = false; });
+    assert(!container.classList.contains('hidden'));
+    game.showGangsterTypeSelection(() => { g2.busy = false; });
+    elements.chooseFist.onclick();
+    assert.strictEqual(g1.busy, false);
+    assert.strictEqual(g2.busy, true);
+    assert(!container.classList.contains('hidden'));
+    game.showGangsterTypeSelection(() => { g3.busy = false; });
+    elements.chooseBrain.onclick();
+    assert.strictEqual(g2.busy, false);
+    assert(!container.classList.contains('hidden'));
+    elements.chooseFace.onclick();
+    assert.strictEqual(g3.busy, false);
+    assert(container.classList.contains('hidden'));
+  });
+});
+
+// simple test runner
+function describe(name, fn){
+  console.log(name);
+  fn();
+}
+function it(name, fn){
+  try {
+    fn();
+    console.log(' ✓', name);
+  } catch (e) {
+    console.error(' ✗', name);
+    console.error(e);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- prevent simultaneous gangster type popups from conflicting by queueing the recruiters and displaying each popup sequentially
- expose Game class for tests and add minimal tests around the recruitment queue

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68902833e26c8326b4cd91fefd9b727c